### PR TITLE
Fix CLI default conversion selection

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,8 +110,8 @@ func MainWithDependencies(exit func(int), userHomeDir func() (string, error)) {
 		args.Src = filepath.Join(homeDir, ".ssh")
 	}
 
-	// default to YAML
-	if !(args.ToYAML && args.ToJSON && args.ToSSH) {
+	// default to YAML when no conversion flag is provided
+	if !(args.ToYAML || args.ToJSON || args.ToSSH) {
 		args.ToYAML = true
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -190,6 +190,13 @@ func TestMainWithDependencies(t *testing.T) {
 			mockHomeDir:    os.UserHomeDir,
 		},
 		{
+			name:           "Successful execution to ssh",
+			args:           []string{"cmd", "--to-ssh", "-src", "testdata/main-test.yaml", "-dest", "test.cfg"},
+			expectedOutput: "File has been saved successfully\nFile path: test.cfg\n",
+			expectedExit:   0,
+			mockHomeDir:    os.UserHomeDir,
+		},
+		{
 			name:           "Error execution",
 			args:           []string{"cmd", "--to-json", "--to-yaml"}, // Invalid args
 			expectedOutput: "Please specify either -to-yaml or -to-ssh or -to-json\n",
@@ -241,7 +248,11 @@ func TestMainWithDependencies(t *testing.T) {
 			}
 
 			if tt.expectedExit == 0 {
-				os.Remove("output.json")
+				for i := 0; i < len(tt.args)-1; i++ {
+					if tt.args[i] == "-dest" || tt.args[i] == "--dest" {
+						os.Remove(tt.args[i+1])
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- ensure the CLI defaults to YAML only when no conversion flag is provided
- add a regression test for the --to-ssh flow and clean up test artifact handling

## Testing
- go test ./... *(fails: internal/fn tests expect permission errors that do not occur when running as root in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_690b0aec98948327a2269faee8f700ad

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes flag logic to default to YAML only when no conversion flags are provided, and adds an --to-ssh regression test with dynamic artifact cleanup.
> 
> - **CLI**:
>   - Fix default conversion selection in `main.go`: set `args.ToYAML = true` only when none of `--to-yaml`, `--to-json`, or `--to-ssh` are provided.
> - **Tests**:
>   - Add `"Successful execution to ssh"` case in `TestMainWithDependencies` to validate `--to-ssh` flow.
>   - Improve cleanup by removing the specified `-dest/--dest` file dynamically instead of hard-coded filename.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02c881f57c0f317823c43edb6e9af37740648253. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->