### PR TITLE
docs: refresh readme for new cli defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@
 
 <img src=".github/github-repo-card.png" >
 
-SSH Config Tool is a command-line utility for managing SSH configuration files. It allows you to manage your SSH config files using more expressive YAML/JSON formats.
+SSH Config Tool is a command-line utility for managing SSH configuration files. It allows you to manage your SSH config files using more expressive YAML/JSON formats while still being able to round-trip them back to classic `ssh_config` syntax.
 
 ## Features
 
-- Supports conversion from YAML/JSON format to standard SSH config format
-- Supports conversion from standard SSH config format to YAML/JSON format
+- Converts YAML/JSON representations into standard SSH config files
+- Converts classic SSH config files into YAML or JSON for easier editing and review
+- Scans a single file or an entire directory tree (such as `~/.ssh`) while skipping key material and other non-config files
 - Supports reading configuration from files or standard input (stdin)
-- Supports output to files or standard output (stdout)
-- Automatically detects input format (YAML/JSON/SSH Config)
+- Supports output to files or standard output (stdout), creating parent folders when needed
+- Automatically detects the input format (YAML/JSON/SSH Config) and tidies trailing blank lines
 
 ## Installation
 
@@ -25,7 +26,13 @@ Use Docker or download the binary file suitable for your system and CPU architec
 ### Basic Usage
 
 ```bash
-ssh-config [options] <input_file> <output_file>
+ssh-config [options]
+```
+
+Run without arguments to export all SSH configuration under `~/.ssh` to YAML on standard output:
+
+```bash
+ssh-config
 ```
 
 Or, use Linux pipes to manipulate files:
@@ -39,52 +46,58 @@ cat input_file | ssh-config -to-yaml > output_file
 Download docker image:
 
 ```bash
-docker pull soulteary/ssh-config:v1.2.0
+docker pull soulteary/ssh-config:latest
 # or
-docker pull ghcr.io/soulteary/ssh-config:v1.2.0
+docker pull ghcr.io/soulteary/ssh-config:latest
 ```
 
 Convert file (test.yaml) in the current directory to YAML (abc.yaml):
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:v1.2.0 ssh-config -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
+docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
 ```
 
 Just want to see the conversion results:
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:v1.2.0 ssh-config -to-yaml -src /ssh/test.yaml
+docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -to-yaml -src /ssh/test.yaml
 ```
 
 If you want to use Linux pipelines, you can first enter the Docker interactive command line:
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:v1.2.0 bash
+docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest bash
 cat /ssh/test.yaml | ssh-config -to-yaml
 ```
 
 ### Options
 
 - `-to-yaml, -to-json, -to-ssh`: Specify output format (yaml/json/config), only one output format can be specified at a time.
-- `-src`: Specify the original configuration file or directory to read from
-- `-dest`: Specify the path to save the configuration file
+- `-src`: Specify the original configuration file or directory to read from. When omitted, the tool scans `~/.ssh`.
+- `-dest`: Specify the path to save the configuration file. When omitted, the converted result is written to standard output.
 - `-help`: View program command-line help
 
 ### Examples
 
-1. Convert YAML format to SSH config format:
+1. Export the SSH configuration for your current user to YAML (default behaviour):
+
+```bash
+ssh-config
+```
+
+2. Convert YAML format to SSH config format:
 
 ```bash
 ssh-config -to-ssh -src input.yaml -dest output.conf
 ```
 
-2. Convert SSH config format to JSON format:
+3. Convert SSH config format to JSON format:
 
 ```bash
 ssh-config -to-json -src ~/.ssh/config -dest output.json
 ```
 
-3. Read from standard input, output to standard output, and save in YAML format:
+4. Read from standard input, output to standard output, and save in YAML format:
 
 ```bash
 cat input.conf | ssh-config -to-yaml > output.yaml


### PR DESCRIPTION
## Summary
- document the new default behaviour that exports ~/.ssh to YAML when no flags are provided
- describe directory scanning, stdout handling, and other current runtime features
- update docker commands to use the rolling latest tag in examples

## Testing
- go test ./... *(fails: permission-based tests expect restricted filesystem access in this container)*

------
https://chatgpt.com/codex/tasks/task_e_690b9c3149008327927036d056037251

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refresh README to document new no-arg default export, directory scanning, I/O behaviors, and updated Docker/latest usage.
> 
> - **Docs (README)**:
>   - **Usage**:
>     - Default no-arg behavior exporting `~/.ssh` to YAML on stdout.
>     - Updated basic invocation and pipe examples.
>     - Clarified `-src` and `-dest` defaults.
>   - **Features**:
>     - Directory/file scanning with non-config files skipped.
>     - Input format auto-detection and tidy trailing blank lines.
>     - Output can create parent folders.
>   - **Docker**:
>     - Examples switched to `:latest` tag and refreshed run commands.
>   - **Examples**:
>     - Reordered/expanded to highlight default export, YAML/JSON/SSH conversions, and stdin/stdout usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e959659d0eac65f8fd13a89dca995be1e73c152. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->