### PR TITLE
Improve SSH config file handling

### DIFF
--- a/internal/fn/fs_permissions.go
+++ b/internal/fn/fs_permissions.go
@@ -1,0 +1,24 @@
+package fn
+
+import "os"
+
+func isFileReadable(info os.FileInfo) bool {
+	perm := info.Mode().Perm()
+	return perm&0400 != 0 || perm&0040 != 0 || perm&0004 != 0
+}
+
+func isDirReadable(info os.FileInfo) bool {
+	perm := info.Mode().Perm()
+	user := perm&0500 == 0500
+	group := perm&0050 == 0050
+	other := perm&0005 == 0005
+	return user || group || other
+}
+
+func isDirWritable(info os.FileInfo) bool {
+	perm := info.Mode().Perm()
+	user := perm&0300 == 0300
+	group := perm&0030 == 0030
+	other := perm&0003 == 0003
+	return user || group || other
+}


### PR DESCRIPTION
## Summary
- ensure SSH config contents are read in a stable order when aggregating files
- validate filesystem permissions when scanning configs and saving output
- add helpers for checking directory and file accessibility

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_690cc5c0eb1483279bff214d87d468fd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make SSH config aggregation deterministic and enforce read/write permission checks during scanning and saving.
> 
> - **SSH config aggregation (`internal/fn/fn.go`)**:
>   - Read configs in a stable order by sorting `filePaths` before concatenation.
>   - Return wrapped error if any file read fails.
> - **Filesystem permissions**:
>   - New helpers in `internal/fn/fs_permissions.go`: `isFileReadable`, `isDirReadable`, `isDirWritable`.
>   - Scanner (`internal/fn/scanner.go`):
>     - Validate directory readability; error on inaccessible dirs; skip unreadable files.
>     - Check readability for single-file input before processing.
>   - Save (`Save` in `internal/fn/fn.go`):
>     - Use `ensureDirectory` to validate/create target dir and parent; verify writability before writing.
> - **Utilities**:
>   - Added `ensureDirectory` with stricter dir existence/type and parent writability checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bce492e4b4a02c91214ed967523f25dfc5b9d592. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->