### PR TITLE
feat: add lossless SSH config syntax tree

### DIFF
--- a/pkg/sshconfig/doc.go
+++ b/pkg/sshconfig/doc.go
@@ -1,0 +1,7 @@
+// Package sshconfig provides a lossless syntax model for OpenSSH client
+// configuration files.
+//
+// Parsing is deliberately separate from evaluating a configuration for a
+// particular host. The syntax model retains comments, whitespace, quoting,
+// line endings, repeated directives, and unknown directives.
+package sshconfig

--- a/pkg/sshconfig/document.go
+++ b/pkg/sshconfig/document.go
@@ -1,0 +1,136 @@
+package sshconfig
+
+import (
+	"bytes"
+	"strings"
+)
+
+// NodeID identifies a node within a Document.
+type NodeID int
+
+// Span is a half-open byte range in the original document.
+type Span struct {
+	Start int
+	End   int
+}
+
+// Position identifies a byte position in the original document.
+type Position struct {
+	Offset int
+	Line   int
+	Column int
+}
+
+// NodeKind describes a top-level syntax node.
+type NodeKind uint8
+
+const (
+	NodeBlank NodeKind = iota
+	NodeComment
+	NodeDirective
+	NodeInvalid
+)
+
+// QuoteStyle records how an argument was quoted in the source.
+type QuoteStyle uint8
+
+const (
+	QuoteNone QuoteStyle = iota
+	QuoteSingle
+	QuoteDouble
+)
+
+// Token is a source-backed syntax token.
+type Token struct {
+	Span     Span
+	Position Position
+}
+
+// Argument is one parsed directive argument. Value is its decoded value;
+// Span and Quote retain its original representation.
+type Argument struct {
+	Token
+	Value string
+	Quote QuoteStyle
+}
+
+// Directive is a parsed directive line. KeywordValue is lower-cased for
+// comparisons while Keyword retains its original spelling.
+type Directive struct {
+	Keyword      Token
+	KeywordValue string
+	Separator    Span
+	Arguments    []Argument
+	Comment      *Token
+	LineEnding   Span
+}
+
+// Node is one physical line in a configuration file. Its span includes the
+// original line ending, when present.
+type Node struct {
+	ID        NodeID
+	Kind      NodeKind
+	Span      Span
+	Directive *Directive
+}
+
+// Diagnostic records a recoverable syntax problem. Lossless parsing keeps
+// the affected bytes and returns them as an invalid node.
+type Diagnostic struct {
+	Position Position
+	Message  string
+}
+
+// Document is a lossless, source-backed syntax tree.
+type Document struct {
+	source      []byte
+	nodes       []Node
+	diagnostics []Diagnostic
+	lineEnding  string
+}
+
+// Bytes returns an independent copy of the original document bytes.
+func (d *Document) Bytes() []byte {
+	if d == nil {
+		return nil
+	}
+	return bytes.Clone(d.source)
+}
+
+// Nodes returns a shallow copy of the document nodes. Syntax slices inside a
+// directive must be treated as immutable.
+func (d *Document) Nodes() []Node {
+	if d == nil {
+		return nil
+	}
+	return append([]Node(nil), d.nodes...)
+}
+
+// Diagnostics returns a copy of recoverable parse diagnostics.
+func (d *Document) Diagnostics() []Diagnostic {
+	if d == nil {
+		return nil
+	}
+	return append([]Diagnostic(nil), d.diagnostics...)
+}
+
+// Raw returns an independent copy of the bytes covered by span.
+func (d *Document) Raw(span Span) []byte {
+	if d == nil || span.Start < 0 || span.End < span.Start || span.End > len(d.source) {
+		return nil
+	}
+	return bytes.Clone(d.source[span.Start:span.End])
+}
+
+// Newline returns the first line-ending style found in the source. It
+// defaults to LF for an empty or single-line document.
+func (d *Document) Newline() string {
+	if d == nil || d.lineEnding == "" {
+		return "\n"
+	}
+	return d.lineEnding
+}
+
+func normalizeKeyword(value []byte) string {
+	return strings.ToLower(string(value))
+}

--- a/pkg/sshconfig/parser.go
+++ b/pkg/sshconfig/parser.go
@@ -1,0 +1,195 @@
+package sshconfig
+
+import "fmt"
+
+// Parse constructs a lossless syntax document. Unknown or malformed lines are
+// retained. Malformed quoting is reported through Document.Diagnostics.
+func Parse(input []byte) (*Document, error) {
+	doc := &Document{source: append([]byte(nil), input...)}
+	line, offset := 1, 0
+	for offset < len(doc.source) {
+		contentEnd, lineEnd := scanLine(doc.source, offset)
+		if doc.lineEnding == "" && lineEnd > contentEnd {
+			doc.lineEnding = string(doc.source[contentEnd:lineEnd])
+		}
+		node := parseLine(doc, NodeID(len(doc.nodes)), line, offset, contentEnd, lineEnd)
+		doc.nodes = append(doc.nodes, node)
+		offset = lineEnd
+		line++
+	}
+	return doc, nil
+}
+
+func scanLine(source []byte, start int) (contentEnd, lineEnd int) {
+	for i := start; i < len(source); i++ {
+		switch source[i] {
+		case '\n':
+			return i, i + 1
+		case '\r':
+			if i+1 < len(source) && source[i+1] == '\n' {
+				return i, i + 2
+			}
+			return i, i + 1
+		}
+	}
+	return len(source), len(source)
+}
+
+func parseLine(doc *Document, id NodeID, line, start, contentEnd, lineEnd int) Node {
+	node := Node{ID: id, Span: Span{Start: start, End: lineEnd}}
+	i := skipHorizontalSpace(doc.source, start, contentEnd)
+	if i == contentEnd {
+		node.Kind = NodeBlank
+		return node
+	}
+	if doc.source[i] == '#' {
+		node.Kind = NodeComment
+		return node
+	}
+
+	keywordStart := i
+	for i < contentEnd && !isKeywordDelimiter(doc.source[i]) {
+		i++
+	}
+	if keywordStart == i {
+		node.Kind = NodeInvalid
+		doc.addDiagnostic(line, keywordStart-start+1, keywordStart, "missing configuration keyword")
+		return node
+	}
+
+	directive := &Directive{
+		Keyword: Token{
+			Span:     Span{Start: keywordStart, End: i},
+			Position: Position{Offset: keywordStart, Line: line, Column: keywordStart - start + 1},
+		},
+		KeywordValue: normalizeKeyword(doc.source[keywordStart:i]),
+		LineEnding:   Span{Start: contentEnd, End: lineEnd},
+	}
+
+	separatorStart := i
+	i = skipHorizontalSpace(doc.source, i, contentEnd)
+	if i < contentEnd && doc.source[i] == '=' {
+		i++
+		i = skipHorizontalSpace(doc.source, i, contentEnd)
+	}
+	directive.Separator = Span{Start: separatorStart, End: i}
+
+	var malformed bool
+	directive.Arguments, directive.Comment, malformed = parseArguments(doc, line, start, i, contentEnd)
+	node.Kind = NodeDirective
+	node.Directive = directive
+	if malformed {
+		node.Kind = NodeInvalid
+	}
+	return node
+}
+
+func parseArguments(doc *Document, line, lineStart, start, end int) ([]Argument, *Token, bool) {
+	var arguments []Argument
+	i := start
+	for {
+		i = skipHorizontalSpace(doc.source, i, end)
+		if i >= end {
+			return arguments, nil, false
+		}
+		if doc.source[i] == '#' {
+			comment := &Token{
+				Span:     Span{Start: i, End: end},
+				Position: Position{Offset: i, Line: line, Column: i - lineStart + 1},
+			}
+			return arguments, comment, false
+		}
+
+		argumentStart := i
+		quote := QuoteNone
+		quoteByte := byte(0)
+		if doc.source[i] == '\'' || doc.source[i] == '"' {
+			quoteByte = doc.source[i]
+			if quoteByte == '\'' {
+				quote = QuoteSingle
+			} else {
+				quote = QuoteDouble
+			}
+			i++
+		}
+
+		value := make([]byte, 0, end-i)
+		closed := quoteByte == 0
+		for i < end {
+			ch := doc.source[i]
+			if quoteByte != 0 && ch == quoteByte {
+				i++
+				closed = true
+				break
+			}
+			if quoteByte == 0 && isHorizontalSpace(ch) {
+				break
+			}
+			if ch == '\\' && i+1 < end && isEscapable(doc.source[i+1], quoteByte) {
+				i++
+				value = append(value, doc.source[i])
+				i++
+				continue
+			}
+			value = append(value, ch)
+			i++
+		}
+
+		if !closed {
+			doc.addDiagnostic(line, argumentStart-lineStart+1, argumentStart, "unterminated quoted argument")
+			return arguments, nil, true
+		}
+		if quoteByte != 0 && i < end && !isHorizontalSpace(doc.source[i]) && doc.source[i] != '#' {
+			for i < end && !isHorizontalSpace(doc.source[i]) {
+				value = append(value, doc.source[i])
+				i++
+			}
+		}
+		arguments = append(arguments, Argument{
+			Token: Token{
+				Span:     Span{Start: argumentStart, End: i},
+				Position: Position{Offset: argumentStart, Line: line, Column: argumentStart - lineStart + 1},
+			},
+			Value: string(value),
+			Quote: quote,
+		})
+	}
+}
+
+func (d *Document) addDiagnostic(line, column, offset int, message string) {
+	d.diagnostics = append(d.diagnostics, Diagnostic{
+		Position: Position{Offset: offset, Line: line, Column: column},
+		Message:  message,
+	})
+}
+
+func skipHorizontalSpace(source []byte, start, end int) int {
+	for start < end && isHorizontalSpace(source[start]) {
+		start++
+	}
+	return start
+}
+
+func isHorizontalSpace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\f'
+}
+
+func isKeywordDelimiter(ch byte) bool {
+	return isHorizontalSpace(ch) || ch == '=' || ch == '\'' || ch == '"'
+}
+
+func isEscapable(ch, quote byte) bool {
+	return ch == '\\' || ch == '\'' || ch == '"' || quote == 0 && ch == ' '
+}
+
+// ParseFile reads and parses a single configuration file.
+func ParseFile(path string, readFile func(string) ([]byte, error)) (*Document, error) {
+	if readFile == nil {
+		return nil, fmt.Errorf("sshconfig: read function is nil")
+	}
+	data, err := readFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("sshconfig: read %s: %w", path, err)
+	}
+	return Parse(data)
+}

--- a/pkg/sshconfig/parser_test.go
+++ b/pkg/sshconfig/parser_test.go
@@ -1,0 +1,125 @@
+package sshconfig
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestParsePreservesBytes(t *testing.T) {
+	t.Parallel()
+	tests := map[string][]byte{
+		"empty":              {},
+		"blank":              []byte(" \t\r\n\n"),
+		"comments":           []byte("# one\n  # two\r\n"),
+		"equals":             []byte("Host=example\nSetEnv FOO=bar BAZ=qux\n"),
+		"quotes":             []byte("ProxyCommand \"ssh -W %h:%p jump\" # tail\n"),
+		"single quotes":      []byte("Match exec 'test -f /tmp/file'\n"),
+		"unknown":            []byte("FutureOption   some-value\n"),
+		"repeated":           []byte("IdentityFile a\nIdentityFile b\nHost a\nHost a\n"),
+		"no trailing line":   []byte("Host final"),
+		"invalid quote":      []byte("Host \"unfinished\n"),
+		"non utf8 comment":   {0x23, 0x20, 0xff, '\n'},
+		"carriage return":    []byte("Host old-mac\rUser root\r"),
+		"escaped whitespace": []byte("ProxyCommand ssh\\ jump\n"),
+	}
+	for name, input := range tests {
+		name, input := name, input
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			doc, err := Parse(input)
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			if got := doc.Bytes(); !bytes.Equal(got, input) {
+				t.Fatalf("round trip mismatch\n got: %q\nwant: %q", got, input)
+			}
+		})
+	}
+}
+
+func TestParseDirectiveSyntax(t *testing.T) {
+	t.Parallel()
+	input := []byte("  SetEnv = FOO=bar BAZ=qux # comment\r\nHost=one two\n")
+	doc, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	nodes := doc.Nodes()
+	if len(nodes) != 2 {
+		t.Fatalf("node count = %d, want 2", len(nodes))
+	}
+	first := nodes[0].Directive
+	if first == nil || first.KeywordValue != "setenv" {
+		t.Fatalf("first directive = %#v", first)
+	}
+	values := []string{first.Arguments[0].Value, first.Arguments[1].Value}
+	if want := []string{"FOO=bar", "BAZ=qux"}; !reflect.DeepEqual(values, want) {
+		t.Fatalf("arguments = %v, want %v", values, want)
+	}
+	if got := string(doc.Raw(first.Comment.Span)); got != "# comment" {
+		t.Fatalf("comment = %q", got)
+	}
+	if got := string(doc.Raw(first.LineEnding)); got != "\r\n" {
+		t.Fatalf("line ending = %q", got)
+	}
+	second := nodes[1].Directive
+	if second.KeywordValue != "host" || len(second.Arguments) != 2 {
+		t.Fatalf("second directive = %#v", second)
+	}
+}
+
+func TestMalformedQuoteIsRetainedAndDiagnosed(t *testing.T) {
+	t.Parallel()
+	input := []byte("Host \"unfinished\n")
+	doc, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got := doc.Nodes()[0].Kind; got != NodeInvalid {
+		t.Fatalf("kind = %v, want NodeInvalid", got)
+	}
+	if len(doc.Diagnostics()) != 1 {
+		t.Fatalf("diagnostics = %v", doc.Diagnostics())
+	}
+	if !bytes.Equal(doc.Bytes(), input) {
+		t.Fatal("invalid input was not retained")
+	}
+}
+
+func TestParseFile(t *testing.T) {
+	t.Parallel()
+	doc, err := ParseFile("config", func(path string) ([]byte, error) {
+		if path != "config" {
+			t.Fatalf("path = %q", path)
+		}
+		return []byte("Host example\n"), nil
+	})
+	if err != nil || string(doc.Bytes()) != "Host example\n" {
+		t.Fatalf("ParseFile() = %q, %v", doc.Bytes(), err)
+	}
+
+	wantErr := errors.New("read failed")
+	_, err = ParseFile("missing", func(string) ([]byte, error) { return nil, wantErr })
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("ParseFile() error = %v", err)
+	}
+	if _, err = ParseFile("missing", nil); err == nil {
+		t.Fatal("ParseFile() with nil reader succeeded")
+	}
+}
+
+func FuzzParsePreservesBytes(f *testing.F) {
+	f.Add([]byte("Host example\n    User root\n"))
+	f.Add([]byte("Match host=internal # comment\r\n"))
+	f.Fuzz(func(t *testing.T, input []byte) {
+		doc, err := Parse(input)
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		if got := doc.Bytes(); !bytes.Equal(got, input) {
+			t.Fatalf("round trip mismatch\n got: %q\nwant: %q", got, input)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- add a source-backed `pkg/sshconfig` concrete syntax tree
- preserve comments, whitespace, quoting, line endings, repeated and unknown directives
- follow OpenSSH's first `=` delimiter and argument escaping behavior
- retain malformed input while reporting recoverable diagnostics
- add byte-for-byte round-trip, syntax, error, file, and fuzz tests

## Compatibility

This PR only adds a new package. It does not change the current CLI or structured output formats.

## Testing

- `go test ./...`
- `go test -race ./pkg/sshconfig`

## References

- OpenSSH `readconf.c`
- OpenSSH `misc.c` `strdelim` and `argv_split`
- OpenSSH `ssh_config(5)`