### PR TITLE
feat: add lossless editing and atomic saves

### DIFF
--- a/pkg/sshconfig/document.go
+++ b/pkg/sshconfig/document.go
@@ -72,6 +72,7 @@ type Node struct {
 	Kind      NodeKind
 	Span      Span
 	Directive *Directive
+	original  *Directive
 }
 
 // Diagnostic records a recoverable syntax problem. Lossless parsing keeps
@@ -87,6 +88,9 @@ type Document struct {
 	nodes       []Node
 	diagnostics []Diagnostic
 	lineEnding  string
+	replacement map[NodeID][]byte
+	removed     map[NodeID]bool
+	nextID      NodeID
 }
 
 // Bytes returns an independent copy of the original document bytes.

--- a/pkg/sshconfig/edit.go
+++ b/pkg/sshconfig/edit.go
@@ -1,0 +1,188 @@
+package sshconfig
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// ReplaceDirective replaces one directive while retaining the original
+// indentation, inline comment, and line ending. The rest of the document is
+// not reformatted.
+func (d *Document) ReplaceDirective(id NodeID, keyword string, arguments ...string) error {
+	if d == nil {
+		return fmt.Errorf("sshconfig: nil document")
+	}
+	if keyword == "" {
+		return fmt.Errorf("sshconfig: directive keyword is empty")
+	}
+	index := d.nodeIndex(id)
+	if index < 0 {
+		return fmt.Errorf("sshconfig: node %d not found", id)
+	}
+	node := &d.nodes[index]
+	if node.original == nil {
+		return fmt.Errorf("sshconfig: node %d is not a source directive", id)
+	}
+	d.replacement[id] = d.renderReplacement(*node, keyword, arguments)
+	node.Kind = NodeDirective
+	node.Directive = syntheticDirective(keyword, arguments)
+	d.removed[id] = false
+	return nil
+}
+
+// RemoveNode removes exactly one syntax node. Repeated directives and other
+// nodes with the same keyword are unaffected.
+func (d *Document) RemoveNode(id NodeID) error {
+	if d == nil {
+		return fmt.Errorf("sshconfig: nil document")
+	}
+	if d.nodeIndex(id) < 0 {
+		return fmt.Errorf("sshconfig: node %d not found", id)
+	}
+	d.removed[id] = true
+	return nil
+}
+
+// InsertDirectiveAfter inserts a new directive after an existing node and
+// returns its stable node identifier.
+func (d *Document) InsertDirectiveAfter(after NodeID, keyword string, arguments ...string) (NodeID, error) {
+	if d == nil {
+		return 0, fmt.Errorf("sshconfig: nil document")
+	}
+	if keyword == "" {
+		return 0, fmt.Errorf("sshconfig: directive keyword is empty")
+	}
+	index := d.nodeIndex(after)
+	if index < 0 {
+		return 0, fmt.Errorf("sshconfig: node %d not found", after)
+	}
+	raw := d.renderNewDirective(keyword, arguments)
+	if !d.nodeHasLineEnding(d.nodes[index]) {
+		raw = append([]byte(d.Newline()), raw...)
+	}
+	id := d.nextID
+	d.nextID++
+	node := Node{ID: id, Kind: NodeDirective, Directive: syntheticDirective(keyword, arguments)}
+	d.nodes = append(d.nodes, Node{})
+	copy(d.nodes[index+2:], d.nodes[index+1:])
+	d.nodes[index+1] = node
+	d.replacement[id] = raw
+	return id, nil
+}
+
+// AppendDirective appends a directive to the end of a document.
+func (d *Document) AppendDirective(keyword string, arguments ...string) (NodeID, error) {
+	if d == nil {
+		return 0, fmt.Errorf("sshconfig: nil document")
+	}
+	if keyword == "" {
+		return 0, fmt.Errorf("sshconfig: directive keyword is empty")
+	}
+	raw := d.renderNewDirective(keyword, arguments)
+	for i := len(d.nodes) - 1; i >= 0; i-- {
+		if d.removed[d.nodes[i].ID] {
+			continue
+		}
+		if !d.nodeHasLineEnding(d.nodes[i]) {
+			raw = append([]byte(d.Newline()), raw...)
+		}
+		break
+	}
+	id := d.nextID
+	d.nextID++
+	d.nodes = append(d.nodes, Node{
+		ID:        id,
+		Kind:      NodeDirective,
+		Directive: syntheticDirective(keyword, arguments),
+	})
+	d.replacement[id] = raw
+	return id, nil
+}
+
+func (d *Document) nodeIndex(id NodeID) int {
+	for i := range d.nodes {
+		if d.nodes[i].ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func (d *Document) nodeHasLineEnding(node Node) bool {
+	if raw, ok := d.replacement[node.ID]; ok {
+		return bytes.HasSuffix(raw, []byte("\n")) || bytes.HasSuffix(raw, []byte("\r"))
+	}
+	if node.original != nil {
+		return node.original.LineEnding.End > node.original.LineEnding.Start
+	}
+	return false
+}
+
+func (d *Document) renderReplacement(node Node, keyword string, arguments []string) []byte {
+	original := node.original
+	var out bytes.Buffer
+	out.Write(d.source[node.Span.Start:original.Keyword.Span.Start])
+	out.WriteString(keyword)
+	separator := d.source[original.Separator.Start:original.Separator.End]
+	if len(separator) == 0 {
+		separator = []byte(" ")
+	}
+	if len(arguments) > 0 {
+		out.Write(separator)
+		writeArguments(&out, arguments)
+	}
+	if original.Comment != nil {
+		out.WriteByte(' ')
+		out.Write(d.source[original.Comment.Span.Start:original.Comment.Span.End])
+	}
+	out.Write(d.source[original.LineEnding.Start:original.LineEnding.End])
+	return out.Bytes()
+}
+
+func (d *Document) renderNewDirective(keyword string, arguments []string) []byte {
+	var out bytes.Buffer
+	out.WriteString(keyword)
+	if len(arguments) > 0 {
+		out.WriteByte(' ')
+		writeArguments(&out, arguments)
+	}
+	out.WriteString(d.Newline())
+	return out.Bytes()
+}
+
+func writeArguments(out *bytes.Buffer, arguments []string) {
+	for i, argument := range arguments {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		out.WriteString(quoteArgument(argument))
+	}
+}
+
+func quoteArgument(argument string) string {
+	if argument != "" && !strings.ContainsAny(argument, " \t\r\n#\\\"'") {
+		return argument
+	}
+	var out strings.Builder
+	out.WriteByte('"')
+	for _, ch := range argument {
+		if ch == '\\' || ch == '"' {
+			out.WriteByte('\\')
+		}
+		out.WriteRune(ch)
+	}
+	out.WriteByte('"')
+	return out.String()
+}
+
+func syntheticDirective(keyword string, arguments []string) *Directive {
+	parsed := make([]Argument, 0, len(arguments))
+	for _, argument := range arguments {
+		parsed = append(parsed, Argument{Value: argument})
+	}
+	return &Directive{
+		KeywordValue: strings.ToLower(keyword),
+		Arguments:    parsed,
+	}
+}

--- a/pkg/sshconfig/parser.go
+++ b/pkg/sshconfig/parser.go
@@ -5,7 +5,11 @@ import "fmt"
 // Parse constructs a lossless syntax document. Unknown or malformed lines are
 // retained. Malformed quoting is reported through Document.Diagnostics.
 func Parse(input []byte) (*Document, error) {
-	doc := &Document{source: append([]byte(nil), input...)}
+	doc := &Document{
+		source:      append([]byte(nil), input...),
+		replacement: make(map[NodeID][]byte),
+		removed:     make(map[NodeID]bool),
+	}
 	line, offset := 1, 0
 	for offset < len(doc.source) {
 		contentEnd, lineEnd := scanLine(doc.source, offset)
@@ -17,6 +21,7 @@ func Parse(input []byte) (*Document, error) {
 		offset = lineEnd
 		line++
 	}
+	doc.nextID = NodeID(len(doc.nodes))
 	return doc, nil
 }
 
@@ -78,6 +83,7 @@ func parseLine(doc *Document, id NodeID, line, start, contentEnd, lineEnd int) N
 	directive.Arguments, directive.Comment, malformed = parseArguments(doc, line, start, i, contentEnd)
 	node.Kind = NodeDirective
 	node.Directive = directive
+	node.original = directive
 	if malformed {
 		node.Kind = NodeInvalid
 	}

--- a/pkg/sshconfig/writer.go
+++ b/pkg/sshconfig/writer.go
@@ -1,0 +1,107 @@
+package sshconfig
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// MarshalPreserve serializes the document while copying unchanged nodes
+// directly from the original source.
+func (d *Document) MarshalPreserve() ([]byte, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sshconfig: nil document")
+	}
+	var out bytes.Buffer
+	for _, node := range d.nodes {
+		if d.removed[node.ID] {
+			continue
+		}
+		if replacement, ok := d.replacement[node.ID]; ok {
+			out.Write(replacement)
+			continue
+		}
+		if node.Span.Start < 0 || node.Span.End < node.Span.Start || node.Span.End > len(d.source) {
+			return nil, fmt.Errorf("sshconfig: invalid span for node %d", node.ID)
+		}
+		out.Write(d.source[node.Span.Start:node.Span.End])
+	}
+	return out.Bytes(), nil
+}
+
+// SaveOptions controls atomic file replacement.
+type SaveOptions struct {
+	// Mode is used for a new file. Zero defaults to 0600.
+	Mode fs.FileMode
+	// PreserveMode retains an existing regular file's permission bits.
+	PreserveMode bool
+}
+
+// Save atomically writes a document to path. Symbolic-link destinations are
+// rejected so a caller cannot unintentionally replace a link target.
+func (d *Document) Save(path string, options SaveOptions) error {
+	data, err := d.MarshalPreserve()
+	if err != nil {
+		return err
+	}
+	return SaveAtomic(path, data, options)
+}
+
+// SaveAtomic writes data to a temporary file in the destination directory,
+// syncs it, and atomically renames it over path.
+func SaveAtomic(path string, data []byte, options SaveOptions) error {
+	if path == "" {
+		return fmt.Errorf("sshconfig: destination path is empty")
+	}
+	mode := options.Mode.Perm()
+	if mode == 0 {
+		mode = 0600
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("sshconfig: refusing symbolic-link destination %s", path)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("sshconfig: destination %s is not a regular file", path)
+		}
+		if options.PreserveMode {
+			mode = info.Mode().Perm()
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("sshconfig: inspect destination %s: %w", path, err)
+	}
+
+	directory := filepath.Dir(path)
+	temp, err := os.CreateTemp(directory, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("sshconfig: create temporary file: %w", err)
+	}
+	tempPath := temp.Name()
+	closed := false
+	defer func() {
+		if !closed {
+			_ = temp.Close()
+		}
+		_ = os.Remove(tempPath)
+	}()
+
+	if err := temp.Chmod(mode); err != nil {
+		return fmt.Errorf("sshconfig: set temporary file mode: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		return fmt.Errorf("sshconfig: write temporary file: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		return fmt.Errorf("sshconfig: sync temporary file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("sshconfig: close temporary file: %w", err)
+	}
+	closed = true
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("sshconfig: replace destination %s: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/sshconfig/writer_test.go
+++ b/pkg/sshconfig/writer_test.go
@@ -1,0 +1,133 @@
+package sshconfig
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMarshalPreserveWithoutEdits(t *testing.T) {
+	t.Parallel()
+	input := []byte("# comment\r\nHost=example\r\n\tUser root\r\n")
+	doc, _ := Parse(input)
+	got, err := doc.MarshalPreserve()
+	if err != nil {
+		t.Fatalf("MarshalPreserve() error = %v", err)
+	}
+	if !bytes.Equal(got, input) {
+		t.Fatalf("output = %q, want %q", got, input)
+	}
+}
+
+func TestReplaceDirectivePreservesSurroundings(t *testing.T) {
+	t.Parallel()
+	input := []byte("Host example\r\n\tUser = old # account\r\nIdentityFile first\r\nIdentityFile second\r\n")
+	doc, _ := Parse(input)
+	if err := doc.ReplaceDirective(1, "User", "new user"); err != nil {
+		t.Fatalf("ReplaceDirective() error = %v", err)
+	}
+	got, err := doc.MarshalPreserve()
+	if err != nil {
+		t.Fatalf("MarshalPreserve() error = %v", err)
+	}
+	want := []byte("Host example\r\n\tUser = \"new user\" # account\r\nIdentityFile first\r\nIdentityFile second\r\n")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveAndInsertDirective(t *testing.T) {
+	t.Parallel()
+	doc, _ := Parse([]byte("Host example\nIdentityFile first"))
+	if err := doc.RemoveNode(1); err != nil {
+		t.Fatalf("RemoveNode() error = %v", err)
+	}
+	id, err := doc.InsertDirectiveAfter(0, "IdentityFile", "second")
+	if err != nil {
+		t.Fatalf("InsertDirectiveAfter() error = %v", err)
+	}
+	if id < 2 {
+		t.Fatalf("inserted id = %d", id)
+	}
+	if _, err := doc.AppendDirective("SetEnv", "FOO=bar", "HASH=#value"); err != nil {
+		t.Fatalf("AppendDirective() error = %v", err)
+	}
+	got, _ := doc.MarshalPreserve()
+	want := "Host example\nIdentityFile second\nSetEnv FOO=bar \"HASH=#value\"\n"
+	if string(got) != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestEditErrors(t *testing.T) {
+	t.Parallel()
+	doc, _ := Parse([]byte("# comment\n"))
+	if err := doc.ReplaceDirective(0, "User", "root"); err == nil {
+		t.Fatal("replaced a comment node")
+	}
+	if err := doc.RemoveNode(99); err == nil {
+		t.Fatal("removed an unknown node")
+	}
+	if _, err := doc.InsertDirectiveAfter(99, "User", "root"); err == nil {
+		t.Fatal("inserted after an unknown node")
+	}
+	if _, err := doc.AppendDirective(""); err == nil {
+		t.Fatal("appended an empty keyword")
+	}
+}
+
+func TestSaveAtomic(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	path := filepath.Join(directory, "config")
+	if err := os.WriteFile(path, []byte("old"), 0640); err != nil {
+		t.Fatal(err)
+	}
+	doc, _ := Parse([]byte("Host example\n"))
+	if err := doc.Save(path, SaveOptions{PreserveMode: true}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "Host example\n" {
+		t.Fatalf("saved content = %q", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotMode := info.Mode().Perm(); gotMode != 0640 {
+		t.Fatalf("saved mode = %o, want 640", gotMode)
+	}
+	matches, err := filepath.Glob(filepath.Join(directory, ".config.tmp-*"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("temporary files remain: %v, %v", matches, err)
+	}
+}
+
+func TestSaveAtomicRejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symbolic links require additional privileges on Windows")
+	}
+	t.Parallel()
+	directory := t.TempDir()
+	target := filepath.Join(directory, "target")
+	link := filepath.Join(directory, "config")
+	if err := os.WriteFile(target, []byte("unchanged"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveAtomic(link, []byte("changed"), SaveOptions{}); err == nil {
+		t.Fatal("SaveAtomic() accepted a symbolic link")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil || string(got) != "unchanged" {
+		t.Fatalf("target changed: %q, %v", got, err)
+	}
+}


### PR DESCRIPTION
## Summary

- add stable node-level replace, remove, insert, and append operations
- rewrite only edited directives while preserving surrounding indentation, comments, and line endings
- quote new arguments without losing embedded `=` or `#`
- add preserve-mode serialization for mixed original and edited nodes
- add atomic same-directory saves with `fsync`, permission preservation, and symlink refusal
- cover edits, repeated directives, CRLF, permissions, cleanup, and symlink safety

## Stack

- depends on #11
- merge this PR after #11

## Testing

- `go test ./...`
- `go test -race ./pkg/sshconfig`