### PR TITLE
feat: validate OpenSSH configuration keywords

### DIFF
--- a/pkg/sshconfig/keywords.go
+++ b/pkg/sshconfig/keywords.go
@@ -1,0 +1,85 @@
+package sshconfig
+
+import "strings"
+
+// KeywordStatus describes how the OpenSSH client treats a directive name.
+type KeywordStatus uint8
+
+const (
+	KeywordSupported KeywordStatus = iota
+	KeywordIgnored
+	KeywordDeprecated
+	KeywordUnsupported
+	KeywordPlatformDependent
+)
+
+// KeywordInfo describes an OpenSSH client configuration keyword.
+type KeywordInfo struct {
+	Name   string
+	Status KeywordStatus
+}
+
+// The registry follows openssh-portable readconf.c as of OpenBSD revision
+// 1.415 (2026-07-21). It is data derived from the public keyword table, not a
+// translation of OpenSSH's evaluator.
+var keywordRegistry = buildKeywordRegistry()
+
+// LookupKeyword performs a case-insensitive OpenSSH keyword lookup.
+func LookupKeyword(name string) (KeywordInfo, bool) {
+	info, ok := keywordRegistry[strings.ToLower(name)]
+	return info, ok
+}
+
+func buildKeywordRegistry() map[string]KeywordInfo {
+	registry := make(map[string]KeywordInfo)
+	add := func(status KeywordStatus, names string) {
+		for _, name := range strings.Fields(names) {
+			registry[name] = KeywordInfo{Name: name, Status: status}
+		}
+	}
+
+	add(KeywordIgnored, `
+		protocol
+	`)
+	add(KeywordDeprecated, `
+		cipher fallbacktorsh globalknownhostsfile2 rhostsauthentication
+		userknownhostsfile2 useroaming usersh useprivilegedport
+	`)
+	add(KeywordUnsupported, `
+		afstokenpassing kerberosauthentication kerberostgtpassing
+		rsaauthentication rhostsrsaauthentication compressionlevel
+	`)
+	add(KeywordPlatformDependent, `
+		gssapiauthentication gssapidelegatecredentials pkcs11provider
+		smartcarddevice
+	`)
+	add(KeywordSupported, `
+		addkeystoagent addressfamily batchmode bindaddress bindinterface
+		canonicaldomains canonicalizefallbacklocal canonicalizehostname
+		canonicalizemaxdots canonicalizepermittedcnames casignaturealgorithms
+		certificatefile challengeresponseauthentication channeltimeout checkhostip
+		ciphers clearallforwardings compression connectionattempts connecttimeout
+		controlmaster controlpath controlpersist dsaauthentication dynamicforward
+		enableescapecommandline enablesshkeysign escapechar exitonforwardfailure
+		fingerprinthash forkafterauthentication forwardagent forwardx11
+		forwardx11timeout forwardx11trusted gatewayports globalknownhostsfile
+		hashknownhosts host hostbasedacceptedalgorithms hostbasedauthentication
+		hostbasedkeytypes hostkeyalgorithms hostkeyalias hostname identityagent
+		identityfile identityfile2 identitiesonly ignoreunknown include ipqos
+		kbdinteractiveauthentication kbdinteractivedevices keepalive
+		knownhostscommand kexalgorithms localcommand localforward loglevel
+		logverbose match macs nohostauthenticationforlocalhost
+		numberofpasswordprompts obscurekeystroketiming passwordauthentication
+		permitlocalcommand permitremoteopen port preferredauthentications
+		proxycommand proxyjump proxyusefdpass pubkeyacceptedalgorithms
+		pubkeyacceptedkeytypes pubkeyauthentication refuseconnection rekeylimit
+		remotecommand remoteforward requesttty requiredrsasize revokedhostkeys
+		securitykeyprovider sendenv serveralivecountmax serveraliveinterval
+		sessiontype setenv skeyauthentication stdinnull streamlocalbindmask
+		streamlocalbindunlink stricthostkeychecking syslogfacility tag
+		tcpkeepalive tisauthentication tunnel tunneldevice updatehostkeys user
+		userknownhostsfile verifyhostkeydns versionaddendum visualhostkey
+		warnweakcrypto xauthlocation
+	`)
+	return registry
+}

--- a/pkg/sshconfig/validate.go
+++ b/pkg/sshconfig/validate.go
@@ -1,0 +1,133 @@
+package sshconfig
+
+import "fmt"
+
+// Severity is the importance of a validation issue.
+type Severity uint8
+
+const (
+	SeverityInfo Severity = iota
+	SeverityWarning
+	SeverityError
+)
+
+// UnknownDirectivePolicy controls diagnostics for directives absent from the
+// OpenSSH keyword registry.
+type UnknownDirectivePolicy uint8
+
+const (
+	UnknownDirectiveIgnore UnknownDirectivePolicy = iota
+	UnknownDirectiveWarn
+	UnknownDirectiveError
+)
+
+// ValidateOptions controls syntax and keyword validation.
+type ValidateOptions struct {
+	UnknownDirective UnknownDirectivePolicy
+}
+
+// ValidationIssue is a structured, source-positioned diagnostic.
+type ValidationIssue struct {
+	NodeID   NodeID
+	Position Position
+	Severity Severity
+	Code     string
+	Message  string
+}
+
+// Validate checks syntax and OpenSSH keyword compatibility without changing
+// or evaluating the document.
+func (d *Document) Validate(options ValidateOptions) []ValidationIssue {
+	if d == nil {
+		return []ValidationIssue{{
+			Severity: SeverityError,
+			Code:     "nil-document",
+			Message:  "document is nil",
+		}}
+	}
+	issues := make([]ValidationIssue, 0, len(d.diagnostics))
+	for _, diagnostic := range d.diagnostics {
+		issues = append(issues, ValidationIssue{
+			NodeID:   d.nodeIDAtOffset(diagnostic.Position.Offset),
+			Position: diagnostic.Position,
+			Severity: SeverityError,
+			Code:     "invalid-syntax",
+			Message:  diagnostic.Message,
+		})
+	}
+	for _, node := range d.nodes {
+		if d.removed[node.ID] || node.Directive == nil {
+			continue
+		}
+		directive := node.Directive
+		position := directive.Keyword.Position
+		if position.Line == 0 {
+			position = Position{Line: 1, Column: 1}
+		}
+		if len(directive.Arguments) == 0 {
+			issues = append(issues, ValidationIssue{
+				NodeID:   node.ID,
+				Position: position,
+				Severity: SeverityError,
+				Code:     "missing-argument",
+				Message:  fmt.Sprintf("directive %q requires an argument", directive.KeywordValue),
+			})
+		}
+
+		info, ok := LookupKeyword(directive.KeywordValue)
+		if !ok {
+			severity, report := unknownSeverity(options.UnknownDirective)
+			if report {
+				issues = append(issues, ValidationIssue{
+					NodeID:   node.ID,
+					Position: position,
+					Severity: severity,
+					Code:     "unknown-directive",
+					Message:  fmt.Sprintf("unknown OpenSSH directive %q", directive.KeywordValue),
+				})
+			}
+			continue
+		}
+		switch info.Status {
+		case KeywordIgnored:
+			issues = append(issues, keywordIssue(node.ID, position, SeverityInfo, "ignored-directive", info.Name, "is ignored by OpenSSH"))
+		case KeywordDeprecated:
+			issues = append(issues, keywordIssue(node.ID, position, SeverityWarning, "deprecated-directive", info.Name, "is deprecated by OpenSSH"))
+		case KeywordUnsupported:
+			issues = append(issues, keywordIssue(node.ID, position, SeverityWarning, "unsupported-directive", info.Name, "is unsupported by OpenSSH"))
+		case KeywordPlatformDependent:
+			issues = append(issues, keywordIssue(node.ID, position, SeverityInfo, "platform-dependent-directive", info.Name, "depends on OpenSSH build features"))
+		}
+	}
+	return issues
+}
+
+func unknownSeverity(policy UnknownDirectivePolicy) (Severity, bool) {
+	switch policy {
+	case UnknownDirectiveWarn:
+		return SeverityWarning, true
+	case UnknownDirectiveError:
+		return SeverityError, true
+	default:
+		return SeverityInfo, false
+	}
+}
+
+func keywordIssue(id NodeID, position Position, severity Severity, code, name, suffix string) ValidationIssue {
+	return ValidationIssue{
+		NodeID:   id,
+		Position: position,
+		Severity: severity,
+		Code:     code,
+		Message:  fmt.Sprintf("directive %q %s", name, suffix),
+	}
+}
+
+func (d *Document) nodeIDAtOffset(offset int) NodeID {
+	for _, node := range d.nodes {
+		if offset >= node.Span.Start && offset < node.Span.End {
+			return node.ID
+		}
+	}
+	return 0
+}

--- a/pkg/sshconfig/validate_test.go
+++ b/pkg/sshconfig/validate_test.go
@@ -1,0 +1,87 @@
+package sshconfig
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestLookupKeyword(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status KeywordStatus
+	}{
+		{"ProxyJump", KeywordSupported},
+		{"MATCH", KeywordSupported},
+		{"Protocol", KeywordIgnored},
+		{"Cipher", KeywordDeprecated},
+		{"KerberosAuthentication", KeywordUnsupported},
+		{"PKCS11Provider", KeywordPlatformDependent},
+	}
+	for _, test := range tests {
+		info, ok := LookupKeyword(test.name)
+		if !ok || info.Status != test.status {
+			t.Errorf("LookupKeyword(%q) = %#v, %v", test.name, info, ok)
+		}
+	}
+	if _, ok := LookupKeyword("FutureOption"); ok {
+		t.Fatal("future option unexpectedly registered")
+	}
+}
+
+func TestValidateReportsWithoutChangingSource(t *testing.T) {
+	t.Parallel()
+	input := []byte("Host example\nFutureOption value\nCipher old\nProtocol 2\nKerberosAuthentication yes\n")
+	doc, _ := Parse(input)
+	issues := doc.Validate(ValidateOptions{UnknownDirective: UnknownDirectiveError})
+	wantCodes := map[string]bool{
+		"unknown-directive":     false,
+		"deprecated-directive":  false,
+		"ignored-directive":     false,
+		"unsupported-directive": false,
+	}
+	for _, issue := range issues {
+		if _, ok := wantCodes[issue.Code]; ok {
+			wantCodes[issue.Code] = true
+		}
+	}
+	for code, found := range wantCodes {
+		if !found {
+			t.Errorf("missing issue %q: %#v", code, issues)
+		}
+	}
+	got, err := doc.MarshalPreserve()
+	if err != nil || !bytes.Equal(got, input) {
+		t.Fatalf("validation changed source: %q, %v", got, err)
+	}
+}
+
+func TestValidateSyntaxAndArguments(t *testing.T) {
+	t.Parallel()
+	doc, _ := Parse([]byte("Host\nUser \"unfinished\n"))
+	issues := doc.Validate(ValidateOptions{})
+	var syntax, missing bool
+	for _, issue := range issues {
+		syntax = syntax || issue.Code == "invalid-syntax"
+		missing = missing || issue.Code == "missing-argument"
+	}
+	if !syntax || !missing {
+		t.Fatalf("issues = %#v", issues)
+	}
+}
+
+func TestUnknownDirectivePolicies(t *testing.T) {
+	t.Parallel()
+	doc, _ := Parse([]byte("FutureOption value\n"))
+	if got := doc.Validate(ValidateOptions{UnknownDirective: UnknownDirectiveIgnore}); len(got) != 0 {
+		t.Fatalf("ignore issues = %#v", got)
+	}
+	warn := doc.Validate(ValidateOptions{UnknownDirective: UnknownDirectiveWarn})
+	if len(warn) != 1 || warn[0].Severity != SeverityWarning {
+		t.Fatalf("warn issues = %#v", warn)
+	}
+	fail := doc.Validate(ValidateOptions{UnknownDirective: UnknownDirectiveError})
+	if len(fail) != 1 || fail[0].Severity != SeverityError {
+		t.Fatalf("error issues = %#v", fail)
+	}
+}


### PR DESCRIPTION
## Summary

- add a case-insensitive OpenSSH client keyword registry derived from `readconf.c`
- classify supported, ignored, deprecated, unsupported, and build-dependent directives
- add structured source-positioned diagnostics
- support ignore, warning, and error policies for future unknown directives
- keep validation side-effect free and byte-preserving

## Stack

- depends on #11 and #12
- merge after #12

## Testing

- `go test ./...`
- `go test -race ./pkg/sshconfig`

## Upstream reference

OpenSSH portable `readconf.c`, OpenBSD revision 1.415 (2026-07-21).