### PR TITLE
feat: resolve OpenSSH Include file graphs

### DIFF
--- a/pkg/sshconfig/include.go
+++ b/pkg/sshconfig/include.go
@@ -1,0 +1,223 @@
+package sshconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const defaultIncludeDepth = 16
+
+// ResolveOptions controls OpenSSH Include path expansion.
+type ResolveOptions struct {
+	// MaxDepth defaults to OpenSSH's READCONF_MAX_DEPTH value of 16.
+	MaxDepth int
+	// RelativeBase is used for non-absolute Include paths. When empty,
+	// UserHome/.ssh is used if UserHome is set, otherwise the entry file's
+	// directory is used.
+	RelativeBase string
+	UserHome     string
+	// Environment enables ${NAME} expansion using this explicit map. A nil
+	// map disables environment expansion.
+	Environment map[string]string
+	// Tokens supplies OpenSSH-style percent token values, for example 'h'.
+	Tokens map[byte]string
+	// CheckPermissions rejects files writable by group or others.
+	CheckPermissions bool
+}
+
+// ResolvedFile is one parsed file in an Include graph.
+type ResolvedFile struct {
+	Path     string
+	Document *Document
+}
+
+// IncludeEdge records one Include directive and its lexically ordered files.
+type IncludeEdge struct {
+	FromPath string
+	NodeID   NodeID
+	Pattern  string
+	Targets  []string
+}
+
+// DocumentGraph retains all source documents and Include relationships.
+type DocumentGraph struct {
+	Entry string
+	Files map[string]*ResolvedFile
+	Edges []IncludeEdge
+	// Order records traversal order, including repeated non-recursive includes.
+	Order []string
+}
+
+// ResolveIncludes parses entry and recursively builds its Include graph.
+// Include directives are retained in their source documents.
+func ResolveIncludes(entry string, options ResolveOptions) (*DocumentGraph, error) {
+	if entry == "" {
+		return nil, fmt.Errorf("sshconfig: include entry path is empty")
+	}
+	absolute, err := filepath.Abs(entry)
+	if err != nil {
+		return nil, fmt.Errorf("sshconfig: resolve entry path: %w", err)
+	}
+	absolute = filepath.Clean(absolute)
+	if options.MaxDepth <= 0 {
+		options.MaxDepth = defaultIncludeDepth
+	}
+	if options.RelativeBase == "" {
+		if options.UserHome != "" {
+			options.RelativeBase = filepath.Join(options.UserHome, ".ssh")
+		} else {
+			options.RelativeBase = filepath.Dir(absolute)
+		}
+	}
+	graph := &DocumentGraph{
+		Entry: absolute,
+		Files: make(map[string]*ResolvedFile),
+	}
+	if err := graph.resolveFile(absolute, options, 0, make(map[string]bool)); err != nil {
+		return nil, err
+	}
+	return graph, nil
+}
+
+func (g *DocumentGraph) resolveFile(path string, options ResolveOptions, depth int, stack map[string]bool) error {
+	path = filepath.Clean(path)
+	if depth > options.MaxDepth {
+		return fmt.Errorf("sshconfig: include depth exceeds %d at %s", options.MaxDepth, path)
+	}
+	if stack[path] {
+		return fmt.Errorf("sshconfig: recursive include cycle at %s", path)
+	}
+	if options.CheckPermissions {
+		if err := checkIncludePermissions(path); err != nil {
+			return err
+		}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("sshconfig: read included file %s: %w", path, err)
+	}
+	doc, err := Parse(data)
+	if err != nil {
+		return fmt.Errorf("sshconfig: parse included file %s: %w", path, err)
+	}
+	if _, exists := g.Files[path]; !exists {
+		g.Files[path] = &ResolvedFile{Path: path, Document: doc}
+	}
+	g.Order = append(g.Order, path)
+	stack[path] = true
+	defer delete(stack, path)
+
+	for _, node := range doc.nodes {
+		if node.Directive == nil || node.Directive.KeywordValue != "include" {
+			continue
+		}
+		for _, argument := range node.Directive.Arguments {
+			pattern, err := expandIncludePattern(argument.Value, options)
+			if err != nil {
+				return fmt.Errorf("sshconfig: %s:%d: include %q: %w", path, argument.Position.Line, argument.Value, err)
+			}
+			if !filepath.IsAbs(pattern) {
+				pattern = filepath.Join(options.RelativeBase, pattern)
+			}
+			matches, err := filepath.Glob(filepath.Clean(pattern))
+			if err != nil {
+				return fmt.Errorf("sshconfig: %s:%d: invalid include pattern %q: %w", path, argument.Position.Line, pattern, err)
+			}
+			sort.Strings(matches)
+			edge := IncludeEdge{
+				FromPath: path,
+				NodeID:   node.ID,
+				Pattern:  argument.Value,
+				Targets:  append([]string(nil), matches...),
+			}
+			g.Edges = append(g.Edges, edge)
+			for _, match := range matches {
+				if err := g.resolveFile(match, options, depth+1, stack); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func expandIncludePattern(pattern string, options ResolveOptions) (string, error) {
+	var err error
+	if options.Environment != nil {
+		pattern, err = expandEnvironment(pattern, options.Environment)
+		if err != nil {
+			return "", err
+		}
+	}
+	pattern, err = expandPercentTokens(pattern, options.Tokens)
+	if err != nil {
+		return "", err
+	}
+	if pattern == "~" || strings.HasPrefix(pattern, "~/") || strings.HasPrefix(pattern, `~\`) {
+		if options.UserHome == "" {
+			return "", fmt.Errorf("cannot expand ~ without UserHome")
+		}
+		if pattern == "~" {
+			pattern = options.UserHome
+		} else {
+			pattern = filepath.Join(options.UserHome, pattern[2:])
+		}
+	}
+	return pattern, nil
+}
+
+func expandEnvironment(value string, environment map[string]string) (string, error) {
+	var missing string
+	expanded := os.Expand(value, func(name string) string {
+		result, ok := environment[name]
+		if !ok && missing == "" {
+			missing = name
+		}
+		return result
+	})
+	if missing != "" {
+		return "", fmt.Errorf("environment variable %s is not set", missing)
+	}
+	return expanded, nil
+}
+
+func expandPercentTokens(value string, tokens map[byte]string) (string, error) {
+	var out strings.Builder
+	for i := 0; i < len(value); i++ {
+		if value[i] != '%' {
+			out.WriteByte(value[i])
+			continue
+		}
+		if i+1 >= len(value) {
+			return "", fmt.Errorf("trailing %% token")
+		}
+		i++
+		if value[i] == '%' {
+			out.WriteByte('%')
+			continue
+		}
+		replacement, ok := tokens[value[i]]
+		if !ok {
+			return "", fmt.Errorf("unsupported %%%c token", value[i])
+		}
+		out.WriteString(replacement)
+	}
+	return out.String(), nil
+}
+
+func checkIncludePermissions(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("sshconfig: inspect included file %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("sshconfig: included path %s is not a regular file", path)
+	}
+	if info.Mode().Perm()&0022 != 0 {
+		return fmt.Errorf("sshconfig: bad permissions on %s: mode %o is writable by group or others", path, info.Mode().Perm())
+	}
+	return nil
+}

--- a/pkg/sshconfig/include_test.go
+++ b/pkg/sshconfig/include_test.go
@@ -1,0 +1,144 @@
+package sshconfig
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestResolveIncludesLexicalOrderAndContext(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	includeDirectory := filepath.Join(directory, "config.d")
+	if err := os.Mkdir(includeDirectory, 0700); err != nil {
+		t.Fatal(err)
+	}
+	writeTestConfig(t, filepath.Join(directory, "config"), "Host example\n  Include config.d/*\nMatch host internal\n  Include missing/*\n")
+	writeTestConfig(t, filepath.Join(includeDirectory, "20-second"), "Host second\n")
+	writeTestConfig(t, filepath.Join(includeDirectory, "10-first"), "Host first\n")
+
+	graph, err := ResolveIncludes(filepath.Join(directory, "config"), ResolveOptions{RelativeBase: directory})
+	if err != nil {
+		t.Fatalf("ResolveIncludes() error = %v", err)
+	}
+	wantOrder := []string{
+		filepath.Join(directory, "config"),
+		filepath.Join(includeDirectory, "10-first"),
+		filepath.Join(includeDirectory, "20-second"),
+	}
+	if !reflect.DeepEqual(graph.Order, wantOrder) {
+		t.Fatalf("order = %v, want %v", graph.Order, wantOrder)
+	}
+	if len(graph.Edges) != 2 || len(graph.Edges[1].Targets) != 0 {
+		t.Fatalf("edges = %#v", graph.Edges)
+	}
+	entry := graph.Files[graph.Entry].Document
+	got, _ := entry.MarshalPreserve()
+	want, _ := os.ReadFile(graph.Entry)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatal("resolving includes changed the entry document")
+	}
+}
+
+func TestResolveIncludesExpansions(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	sshDirectory := filepath.Join(directory, ".ssh")
+	if err := os.Mkdir(sshDirectory, 0700); err != nil {
+		t.Fatal(err)
+	}
+	entry := filepath.Join(sshDirectory, "config")
+	writeTestConfig(t, entry, "Include ~/hosts/${PROFILE}/%h.conf\n")
+	targetDirectory := filepath.Join(directory, "hosts", "work")
+	if err := os.MkdirAll(targetDirectory, 0700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(targetDirectory, "server.conf")
+	writeTestConfig(t, target, "Host server\n")
+
+	graph, err := ResolveIncludes(entry, ResolveOptions{
+		UserHome:    directory,
+		Environment: map[string]string{"PROFILE": "work"},
+		Tokens:      map[byte]string{'h': "server"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveIncludes() error = %v", err)
+	}
+	if len(graph.Order) != 2 || graph.Order[1] != target {
+		t.Fatalf("order = %v", graph.Order)
+	}
+}
+
+func TestResolveIncludesCycleAndDepth(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	first := filepath.Join(directory, "first")
+	second := filepath.Join(directory, "second")
+	writeTestConfig(t, first, "Include second\n")
+	writeTestConfig(t, second, "Include first\n")
+	_, err := ResolveIncludes(first, ResolveOptions{RelativeBase: directory})
+	if err == nil || !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("cycle error = %v", err)
+	}
+
+	writeTestConfig(t, second, "Host second\n")
+	_, err = ResolveIncludes(first, ResolveOptions{RelativeBase: directory, MaxDepth: 0})
+	if err != nil {
+		t.Fatalf("default depth error = %v", err)
+	}
+	_, err = ResolveIncludes(first, ResolveOptions{RelativeBase: directory, MaxDepth: -1})
+	if err != nil {
+		t.Fatalf("negative default depth error = %v", err)
+	}
+
+	third := filepath.Join(directory, "third")
+	writeTestConfig(t, second, "Include third\n")
+	writeTestConfig(t, third, "Host third\n")
+	_, err = ResolveIncludes(first, ResolveOptions{RelativeBase: directory, MaxDepth: 1})
+	if err == nil || !strings.Contains(err.Error(), "depth") {
+		t.Fatalf("depth error = %v", err)
+	}
+}
+
+func TestResolveIncludesPermissionCheck(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not portable to Windows")
+	}
+	t.Parallel()
+	directory := t.TempDir()
+	entry := filepath.Join(directory, "config")
+	writeTestConfig(t, entry, "Host example\n")
+	if err := os.Chmod(entry, 0666); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ResolveIncludes(entry, ResolveOptions{CheckPermissions: true})
+	if err == nil || !strings.Contains(err.Error(), "bad permissions") {
+		t.Fatalf("permission error = %v", err)
+	}
+}
+
+func TestResolveIncludesExpansionErrors(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	entry := filepath.Join(directory, "config")
+	writeTestConfig(t, entry, "Include ${MISSING}/%x\n")
+	_, err := ResolveIncludes(entry, ResolveOptions{Environment: map[string]string{}, Tokens: map[byte]string{}})
+	if err == nil || !strings.Contains(err.Error(), "MISSING") {
+		t.Fatalf("environment error = %v", err)
+	}
+	writeTestConfig(t, entry, "Include %x\n")
+	_, err = ResolveIncludes(entry, ResolveOptions{Tokens: map[byte]string{}})
+	if err == nil || !strings.Contains(err.Error(), "%x") {
+		t.Fatalf("token error = %v", err)
+	}
+}
+
+func writeTestConfig(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- build a non-destructive graph of parsed files referenced by `Include`
- preserve Include directives in every source document
- process glob matches in lexical order and keep repeated traversal order
- support explicit `~`, `${ENV}`, and OpenSSH percent-token expansion
- bound recursion to OpenSSH's default depth of 16 and reject cycles
- optionally reject group- or other-writable configuration files
- keep missing glob matches non-fatal, matching OpenSSH behavior

The resolver never evaluates or executes `Match exec`.

## Stack

- depends on #11, #12, and #13
- merge after #13

## Testing

- `go test ./...`
- `go test -race ./pkg/sshconfig`

## Upstream reference

OpenSSH `readconf.c` Include handling and `regress/cfginclude.sh`.