### PR TITLE
feat: add lossless v3 structured schema

### DIFF
--- a/pkg/sshconfig/migrate.go
+++ b/pkg/sshconfig/migrate.go
@@ -1,0 +1,139 @@
+package sshconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type legacyHost struct {
+	Name   string            `json:"Name,omitempty" yaml:"Name,omitempty"`
+	Notes  string            `json:"Notes,omitempty" yaml:"Notes,omitempty"`
+	Data   map[string]string `json:"Data,omitempty" yaml:"-"`
+	Config map[string]string `json:"-" yaml:"config,omitempty"`
+}
+
+type legacyGroup struct {
+	Prefix string                `yaml:"Prefix,omitempty"`
+	Common map[string]string     `yaml:"Common,omitempty"`
+	Hosts  map[string]legacyHost `yaml:"Hosts,omitempty"`
+}
+
+type legacyYAML struct {
+	Global  map[string]string      `yaml:"global,omitempty"`
+	Default map[string]string      `yaml:"default,omitempty"`
+	Groups  map[string]legacyGroup `yaml:",inline"`
+}
+
+// MigrateLegacyYAML converts the previous map-based YAML format into a v3
+// document. It cannot recover ordering or repeated values already absent from
+// the legacy input.
+func MigrateLegacyYAML(data []byte, path string) (Schema, error) {
+	var legacy legacyYAML
+	if err := yaml.UnmarshalStrict(data, &legacy); err != nil {
+		return Schema{}, fmt.Errorf("sshconfig: decode legacy YAML: %w", err)
+	}
+	var output bytes.Buffer
+	writeLegacyHost(&output, "*", "", legacy.Global)
+	groupNames := sortedMapKeys(legacy.Groups)
+	for _, groupName := range groupNames {
+		group := legacy.Groups[groupName]
+		hostNames := sortedMapKeys(group.Hosts)
+		for _, hostName := range hostNames {
+			host := group.Hosts[hostName]
+			config := cloneStringMap(host.Config)
+			if config == nil {
+				config = make(map[string]string)
+			}
+			mergeMissing(config, group.Common)
+			mergeMissing(config, legacy.Default)
+			writeLegacyHost(&output, group.Prefix+hostName, host.Notes, config)
+		}
+	}
+	return schemaFromLegacyBytes(output.Bytes(), path)
+}
+
+// MigrateLegacyJSON converts the previous host-array JSON format into v3.
+func MigrateLegacyJSON(data []byte, path string) (Schema, error) {
+	var hosts []legacyHost
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&hosts); err != nil {
+		return Schema{}, fmt.Errorf("sshconfig: decode legacy JSON: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return Schema{}, err
+	}
+	var output bytes.Buffer
+	for _, host := range hosts {
+		writeLegacyHost(&output, host.Name, host.Notes, host.Data)
+	}
+	return schemaFromLegacyBytes(output.Bytes(), path)
+}
+
+func schemaFromLegacyBytes(data []byte, path string) (Schema, error) {
+	doc, err := Parse(data)
+	if err != nil {
+		return Schema{}, err
+	}
+	schemaDocument, err := doc.ToSchema(path)
+	if err != nil {
+		return Schema{}, err
+	}
+	return NewSchema(schemaDocument), nil
+}
+
+func writeLegacyHost(output *bytes.Buffer, name, notes string, config map[string]string) {
+	if name == "" || len(config) == 0 {
+		return
+	}
+	for _, note := range strings.Split(notes, "\n") {
+		if note != "" {
+			output.WriteString("# ")
+			output.WriteString(note)
+			output.WriteByte('\n')
+		}
+	}
+	output.WriteString("Host ")
+	output.WriteString(quoteArgument(name))
+	output.WriteByte('\n')
+	for _, key := range sortedMapKeys(config) {
+		output.WriteString("    ")
+		output.WriteString(key)
+		output.WriteByte(' ')
+		output.WriteString(quoteArgument(config[key]))
+		output.WriteByte('\n')
+	}
+}
+
+func sortedMapKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func cloneStringMap(input map[string]string) map[string]string {
+	if input == nil {
+		return nil
+	}
+	result := make(map[string]string, len(input))
+	for key, value := range input {
+		result[key] = value
+	}
+	return result
+}
+
+func mergeMissing(destination, source map[string]string) {
+	for key, value := range source {
+		if _, exists := destination[key]; !exists {
+			destination[key] = value
+		}
+	}
+}

--- a/pkg/sshconfig/schema.go
+++ b/pkg/sshconfig/schema.go
@@ -1,0 +1,298 @@
+package sshconfig
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v2"
+)
+
+// SchemaVersion is the lossless structured configuration format version.
+const SchemaVersion = 3
+
+// Schema is the root of the v3 YAML/JSON representation.
+type Schema struct {
+	SchemaVersion int              `json:"schemaVersion" yaml:"schemaVersion"`
+	Documents     []SchemaDocument `json:"documents" yaml:"documents"`
+}
+
+// SchemaDocument is one physical SSH configuration file.
+type SchemaDocument struct {
+	Path  string       `json:"path,omitempty" yaml:"path,omitempty"`
+	Nodes []SchemaNode `json:"nodes" yaml:"nodes"`
+}
+
+// SchemaNode preserves one physical source line. RawBase64 is authoritative
+// while its parsed Directive remains unchanged. If Directive is edited, the
+// importer renders only that node canonically.
+type SchemaNode struct {
+	Type      string           `json:"type" yaml:"type"`
+	RawBase64 string           `json:"rawBase64,omitempty" yaml:"rawBase64,omitempty"`
+	Directive *SchemaDirective `json:"directive,omitempty" yaml:"directive,omitempty"`
+}
+
+// SchemaDirective is an editable semantic view of a directive node.
+type SchemaDirective struct {
+	Keyword   string   `json:"keyword" yaml:"keyword"`
+	Arguments []string `json:"arguments,omitempty" yaml:"arguments,omitempty"`
+	Comment   string   `json:"comment,omitempty" yaml:"comment,omitempty"`
+}
+
+// ToSchema exports a document without discarding its original source bytes.
+func (d *Document) ToSchema(path string) (SchemaDocument, error) {
+	serialized, err := d.MarshalPreserve()
+	if err != nil {
+		return SchemaDocument{}, err
+	}
+	clean, err := Parse(serialized)
+	if err != nil {
+		return SchemaDocument{}, err
+	}
+	result := SchemaDocument{Path: path, Nodes: make([]SchemaNode, 0, len(clean.nodes))}
+	for _, node := range clean.nodes {
+		raw := clean.source[node.Span.Start:node.Span.End]
+		schemaNode := SchemaNode{
+			Type:      schemaNodeType(node.Kind),
+			RawBase64: base64.StdEncoding.EncodeToString(raw),
+		}
+		if node.Directive != nil && utf8.Valid(raw) {
+			directive := node.Directive
+			arguments := make([]string, 0, len(directive.Arguments))
+			for _, argument := range directive.Arguments {
+				arguments = append(arguments, argument.Value)
+			}
+			view := &SchemaDirective{
+				Keyword:   string(clean.source[directive.Keyword.Span.Start:directive.Keyword.Span.End]),
+				Arguments: arguments,
+			}
+			if directive.Comment != nil {
+				view.Comment = string(clean.source[directive.Comment.Span.Start:directive.Comment.Span.End])
+			}
+			schemaNode.Directive = view
+		}
+		result.Nodes = append(result.Nodes, schemaNode)
+	}
+	return result, nil
+}
+
+// NewSchema creates a v3 schema from one or more documents.
+func NewSchema(documents ...SchemaDocument) Schema {
+	return Schema{SchemaVersion: SchemaVersion, Documents: documents}
+}
+
+// Document reconstructs one schema document. An empty path selects the first
+// document when the schema contains exactly one document.
+func (s Schema) Document(path string) (*Document, error) {
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+	for _, document := range s.Documents {
+		if document.Path == path || path == "" && len(s.Documents) == 1 {
+			return document.Document()
+		}
+	}
+	return nil, fmt.Errorf("sshconfig: schema document %q not found", path)
+}
+
+// Document reconstructs a lossless syntax document from a v3 document.
+func (s SchemaDocument) Document() (*Document, error) {
+	var output bytes.Buffer
+	for index, node := range s.Nodes {
+		raw, err := decodeSchemaRaw(node.RawBase64)
+		if err != nil {
+			return nil, fmt.Errorf("sshconfig: schema node %d: %w", index, err)
+		}
+		if node.Directive == nil {
+			if len(raw) == 0 && node.Type != "blank" {
+				return nil, fmt.Errorf("sshconfig: schema node %d has neither raw bytes nor a directive", index)
+			}
+			output.Write(raw)
+			continue
+		}
+		if schemaRawMatchesDirective(raw, node.Directive) {
+			output.Write(raw)
+			continue
+		}
+		output.Write(renderSchemaDirective(node.Directive, detectLineEnding(raw)))
+	}
+	return Parse(output.Bytes())
+}
+
+// Validate checks the v3 envelope and node shapes.
+func (s Schema) Validate() error {
+	if s.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("sshconfig: unsupported schema version %d", s.SchemaVersion)
+	}
+	if len(s.Documents) == 0 {
+		return fmt.Errorf("sshconfig: schema has no documents")
+	}
+	seen := make(map[string]bool)
+	for index, document := range s.Documents {
+		if document.Path != "" {
+			if seen[document.Path] {
+				return fmt.Errorf("sshconfig: duplicate schema document path %q", document.Path)
+			}
+			seen[document.Path] = true
+		}
+		for nodeIndex, node := range document.Nodes {
+			switch node.Type {
+			case "blank", "comment", "directive", "invalid":
+			default:
+				return fmt.Errorf("sshconfig: document %d node %d has unknown type %q", index, nodeIndex, node.Type)
+			}
+			if node.Directive != nil && node.Directive.Keyword == "" {
+				return fmt.Errorf("sshconfig: document %d node %d has an empty keyword", index, nodeIndex)
+			}
+			if node.Type == "directive" && node.Directive == nil && node.RawBase64 == "" {
+				return fmt.Errorf("sshconfig: document %d node %d has no directive or raw bytes", index, nodeIndex)
+			}
+			if node.Type != "directive" && node.Directive != nil {
+				return fmt.Errorf("sshconfig: document %d node %d of type %q has a directive", index, nodeIndex, node.Type)
+			}
+			if _, err := decodeSchemaRaw(node.RawBase64); err != nil {
+				return fmt.Errorf("sshconfig: document %d node %d: %w", index, nodeIndex, err)
+			}
+		}
+	}
+	return nil
+}
+
+// MarshalSchemaJSON serializes a validated schema as indented JSON.
+func MarshalSchemaJSON(schema Schema) ([]byte, error) {
+	if err := schema.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(schema, "", "  ")
+}
+
+// UnmarshalSchemaJSON strictly decodes one JSON schema document.
+func UnmarshalSchemaJSON(data []byte) (Schema, error) {
+	var schema Schema
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&schema); err != nil {
+		return Schema{}, fmt.Errorf("sshconfig: decode v3 JSON: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return Schema{}, err
+	}
+	if err := schema.Validate(); err != nil {
+		return Schema{}, err
+	}
+	return schema, nil
+}
+
+// MarshalSchemaYAML serializes a validated schema as YAML.
+func MarshalSchemaYAML(schema Schema) ([]byte, error) {
+	if err := schema.Validate(); err != nil {
+		return nil, err
+	}
+	return yaml.Marshal(schema)
+}
+
+// UnmarshalSchemaYAML strictly decodes one YAML schema document.
+func UnmarshalSchemaYAML(data []byte) (Schema, error) {
+	var schema Schema
+	if err := yaml.UnmarshalStrict(data, &schema); err != nil {
+		return Schema{}, fmt.Errorf("sshconfig: decode v3 YAML: %w", err)
+	}
+	if err := schema.Validate(); err != nil {
+		return Schema{}, err
+	}
+	return schema, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err == io.EOF {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("sshconfig: decode trailing JSON: %w", err)
+	}
+	return fmt.Errorf("sshconfig: multiple JSON values are not allowed")
+}
+
+func schemaNodeType(kind NodeKind) string {
+	switch kind {
+	case NodeBlank:
+		return "blank"
+	case NodeComment:
+		return "comment"
+	case NodeDirective:
+		return "directive"
+	default:
+		return "invalid"
+	}
+}
+
+func decodeSchemaRaw(encoded string) ([]byte, error) {
+	if encoded == "" {
+		return nil, nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("invalid rawBase64: %w", err)
+	}
+	return decoded, nil
+}
+
+func schemaRawMatchesDirective(raw []byte, expected *SchemaDirective) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	doc, err := Parse(raw)
+	if err != nil || len(doc.nodes) != 1 || doc.nodes[0].Directive == nil {
+		return false
+	}
+	directive := doc.nodes[0].Directive
+	actual := &SchemaDirective{
+		Keyword: string(doc.source[directive.Keyword.Span.Start:directive.Keyword.Span.End]),
+	}
+	for _, argument := range directive.Arguments {
+		actual.Arguments = append(actual.Arguments, argument.Value)
+	}
+	if directive.Comment != nil {
+		actual.Comment = string(doc.source[directive.Comment.Span.Start:directive.Comment.Span.End])
+	}
+	return reflect.DeepEqual(actual, expected)
+}
+
+func renderSchemaDirective(directive *SchemaDirective, lineEnding string) []byte {
+	if lineEnding == "" {
+		lineEnding = "\n"
+	}
+	var output bytes.Buffer
+	output.WriteString(directive.Keyword)
+	if len(directive.Arguments) > 0 {
+		output.WriteByte(' ')
+		writeArguments(&output, directive.Arguments)
+	}
+	if directive.Comment != "" {
+		output.WriteByte(' ')
+		if directive.Comment[0] != '#' {
+			output.WriteByte('#')
+			output.WriteByte(' ')
+		}
+		output.WriteString(directive.Comment)
+	}
+	output.WriteString(lineEnding)
+	return output.Bytes()
+}
+
+func detectLineEnding(raw []byte) string {
+	if bytes.HasSuffix(raw, []byte("\r\n")) {
+		return "\r\n"
+	}
+	if bytes.HasSuffix(raw, []byte("\n")) {
+		return "\n"
+	}
+	if bytes.HasSuffix(raw, []byte("\r")) {
+		return "\r"
+	}
+	return ""
+}

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -1,0 +1,158 @@
+package sshconfig
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestSchemaJSONAndYAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+	input := []byte("# note\r\nHost=example\r\n\tIdentityFile first\r\n\tIdentityFile second # backup\r\n")
+	doc, _ := Parse(input)
+	schemaDocument, err := doc.ToSchema("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := NewSchema(schemaDocument)
+
+	jsonData, err := MarshalSchemaJSON(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromJSON, err := UnmarshalSchemaJSON(jsonData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSchemaDocumentBytes(t, fromJSON, "config", input)
+
+	yamlData, err := MarshalSchemaYAML(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromYAML, err := UnmarshalSchemaYAML(yamlData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSchemaDocumentBytes(t, fromYAML, "config", input)
+}
+
+func TestSchemaPreservesNonUTF8RawBytes(t *testing.T) {
+	t.Parallel()
+	input := []byte{'#', ' ', 0xff, '\n'}
+	doc, _ := Parse(input)
+	schemaDocument, err := doc.ToSchema("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := NewSchema(schemaDocument)
+	data, err := MarshalSchemaJSON(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := UnmarshalSchemaJSON(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSchemaDocumentBytes(t, decoded, "config", input)
+}
+
+func TestSchemaRendersOnlyChangedDirective(t *testing.T) {
+	t.Parallel()
+	input := []byte("# untouched\r\n\tUser = old # account\r\nHost example\r\n")
+	doc, _ := Parse(input)
+	schemaDocument, _ := doc.ToSchema("config")
+	schemaDocument.Nodes[1].Directive.Arguments = []string{"new user"}
+	reconstructed, err := schemaDocument.Document()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := reconstructed.MarshalPreserve()
+	want := []byte("# untouched\r\nUser \"new user\" # account\r\nHost example\r\n")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestSchemaStrictValidation(t *testing.T) {
+	t.Parallel()
+	if _, err := UnmarshalSchemaJSON([]byte(`{"schemaVersion":3,"documents":[],"extra":true}`)); err == nil {
+		t.Fatal("JSON accepted an unknown field")
+	}
+	if _, err := UnmarshalSchemaYAML([]byte("schemaVersion: 3\ndocuments: []\nextra: true\n")); err == nil {
+		t.Fatal("YAML accepted an unknown field")
+	}
+	badVersion := Schema{SchemaVersion: 2, Documents: []SchemaDocument{{}}}
+	if err := badVersion.Validate(); err == nil {
+		t.Fatal("schema accepted an old version")
+	}
+	badBase64 := NewSchema(SchemaDocument{Nodes: []SchemaNode{{Type: "comment", RawBase64: "!"}}})
+	if err := badBase64.Validate(); err == nil {
+		t.Fatal("schema accepted invalid base64")
+	}
+	wrongNodeShape := NewSchema(SchemaDocument{Nodes: []SchemaNode{{
+		Type:      "comment",
+		Directive: &SchemaDirective{Keyword: "Host"},
+	}}})
+	if err := wrongNodeShape.Validate(); err == nil {
+		t.Fatal("schema accepted a directive view on a comment node")
+	}
+}
+
+func TestMigrateLegacyFormats(t *testing.T) {
+	t.Parallel()
+	legacyYAML := []byte(`global:
+  ServerAliveInterval: "30"
+Group production:
+  Prefix: corp-
+  Common:
+    User: deploy
+  Hosts:
+    api:
+      Notes: main API
+      config:
+        HostName: api.example
+`)
+	schema, err := MigrateLegacyYAML(legacyYAML, "config")
+	if err != nil {
+		t.Fatalf("MigrateLegacyYAML() error = %v", err)
+	}
+	doc, err := schema.Document("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	yamlOutput, _ := doc.MarshalPreserve()
+	for _, expected := range []string{"Host *", "ServerAliveInterval 30", "Host corp-api", "User deploy", "HostName api.example"} {
+		if !strings.Contains(string(yamlOutput), expected) {
+			t.Errorf("migrated YAML output missing %q:\n%s", expected, yamlOutput)
+		}
+	}
+
+	legacyJSON := []byte(`[{"Name":"example","Notes":"note","Data":{"User":"root","IdentityFile":"~/.ssh/id"}}]`)
+	schema, err = MigrateLegacyJSON(legacyJSON, "config")
+	if err != nil {
+		t.Fatalf("MigrateLegacyJSON() error = %v", err)
+	}
+	doc, _ = schema.Document("config")
+	jsonOutput, _ := doc.MarshalPreserve()
+	for _, expected := range []string{"# note", "Host example", "IdentityFile ~/.ssh/id", "User root"} {
+		if !strings.Contains(string(jsonOutput), expected) {
+			t.Errorf("migrated JSON output missing %q:\n%s", expected, jsonOutput)
+		}
+	}
+}
+
+func assertSchemaDocumentBytes(t *testing.T, schema Schema, path string, want []byte) {
+	t.Helper()
+	doc, err := schema.Document(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := doc.MarshalPreserve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("schema round trip mismatch\n got: %q\nwant: %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- add a versioned v3 YAML/JSON schema that preserves every physical source line as raw bytes
- expose editable directive views while rewriting only directives whose semantic fields changed
- preserve CRLF, repeated directives, comments, and non-UTF-8 bytes through Base64-backed nodes
- strictly validate schema versions, fields, node shapes, document paths, and encoded data
- add deterministic migration helpers for the existing lossy YAML and JSON formats

## Compatibility

The original map-based formats cannot represent ordering or repeated keys. Migration therefore produces deterministic output but cannot recover information already discarded by those formats.

## Verification

- `go test ./...`
- `go test -race ./pkg/sshconfig`

## Stack

Depends on #11, #12, #13, #14, and #15. Merge this PR after those PRs in order.