### PR TITLE
feat: expose lossless v3 mode in the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ SSH Config Tool is a command-line utility for managing SSH configuration files. 
 - Supports reading configuration from files or standard input (stdin)
 - Supports output to files or standard output (stdout), creating parent folders when needed
 - Automatically detects the input format (YAML/JSON/SSH Config) and tidies trailing blank lines
+- Offers an opt-in lossless v3 format that preserves comments, ordering, repeated directives, quoting, line endings, and unknown directives
 
 ## Installation
 
@@ -82,6 +83,7 @@ cat /ssh/test.yaml | ssh-config -to-yaml
 - `-to-yaml, -to-json, -to-ssh`: Specify output format (yaml/json/config), only one output format can be specified at a time.
 - `-src`: Specify the original configuration file or directory to read from. When omitted, the tool scans `~/.ssh`.
 - `-dest`: Specify the path to save the configuration file. When omitted, the converted result is written to standard output.
+- `-lossless`: Use the lossless parser and v3 YAML/JSON schema. This mode accepts one source file or stdin and writes destination files atomically.
 - `-help`: View program command-line help
 
 ### Examples
@@ -109,6 +111,16 @@ ssh-config -to-json -src ~/.ssh/config -dest output.json
 ```bash
 cat input.conf | ssh-config -to-yaml > output.yaml
 ```
+
+5. Losslessly edit a configuration through the v3 YAML representation:
+
+```bash
+ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+# Edit directive fields in config.v3.yaml. Unchanged lines retain their exact bytes.
+ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+```
+
+The previous YAML/JSON formats remain the default for compatibility. Lossless mode can import them, but ordering and repeated values already discarded by a legacy map cannot be reconstructed.
 
 ## Development
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -15,6 +15,7 @@ SSH Config Tool 是一个用于管理 SSH 配置文件的命令行工具。它�
 - 支持从文件输入或标准输入(stdin)读取配置
 - 支持输出到文件或标准输出(stdout)
 - 自动检测输入格式(YAML/JSON/SSH Config)
+- 提供可选的 v3 无损格式，保留注释、顺序、重复指令、引号、换行符和未知指令
 
 ## 安装
 
@@ -75,6 +76,7 @@ cat /ssh/test.yaml | ssh-config -to-yaml
 - `-to-yaml, -to-json, -to-ssh`: 指定输出格式 (yaml/json/config)，同一时间，输出格式只能指定为一种。
 - `-src`: 指定要读取的原始配置文件，或配置目录
 - `-dest`: 指定要保存的配置文件路径
+- `-lossless`: 使用无损解析器和 v3 YAML/JSON 格式。此模式接受单个源文件或标准输入，并以原子方式写入目标文件。
 - `-help`: 查看程序命令行帮助
 
 ### 示例
@@ -96,6 +98,16 @@ ssh-config -to-json -src ~/.ssh/config -dest output.json
 ```bash
 cat input.conf | ssh-config -to-yaml > output.yaml
 ```
+
+4. 通过 v3 YAML 格式无损编辑配置：
+
+```bash
+ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+# 修改 config.v3.yaml 中的 directive 字段；未修改的行会保留原始字节。
+ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+```
+
+为保持兼容，默认仍使用原有 YAML/JSON 格式。无损模式能够导入旧格式，但无法恢复已经被旧 map 结构丢弃的顺序和重复值。
 
 ## 开发
 

--- a/cmd/argv.go
+++ b/cmd/argv.go
@@ -34,24 +34,27 @@ type Args struct {
 	ToYAML   bool
 	ToSSH    bool
 	ToJSON   bool
+	Lossless bool
 	Src      string
 	Dest     string
 	ShowHelp bool
 }
 
 const (
-	DEFAULT_TO_YAML = false
-	DEFAULT_TO_SSH  = false
-	DEFAULT_TO_JSON = false
-	DEFAULT_SRC     = ""
-	DEFAULT_DEST    = ""
-	DEFAULT_HELP    = false
+	DEFAULT_TO_YAML  = false
+	DEFAULT_TO_SSH   = false
+	DEFAULT_TO_JSON  = false
+	DEFAULT_LOSSLESS = false
+	DEFAULT_SRC      = ""
+	DEFAULT_DEST     = ""
+	DEFAULT_HELP     = false
 )
 
 func initFlags() {
 	flag.BoolVar(&args.ToYAML, "to-yaml", DEFAULT_TO_YAML, "Convert SSH config(Text/JSON) to YAML")
-	flag.BoolVar(&args.ToSSH, "to-ssh", DEFAULT_TO_SSH, "Convert SSH config(YAML/JSON) to YAML")
+	flag.BoolVar(&args.ToSSH, "to-ssh", DEFAULT_TO_SSH, "Convert SSH config(YAML/JSON) to SSH config")
 	flag.BoolVar(&args.ToJSON, "to-json", DEFAULT_TO_JSON, "Convert SSH config(YAML/Text) to JSON")
+	flag.BoolVar(&args.Lossless, "lossless", DEFAULT_LOSSLESS, "Use the lossless v3 parser and structured format")
 	flag.StringVar(&args.Src, "src", DEFAULT_SRC, "Source file or directories path, valid when using non-pipeline mode")
 	flag.StringVar(&args.Dest, "dest", DEFAULT_DEST, "Destination file path, valid when using non-pipeline mode")
 	flag.BoolVar(&args.ShowHelp, "help", DEFAULT_HELP, "Show help")
@@ -71,6 +74,7 @@ func ResetFlags() {
 		ToYAML:   DEFAULT_TO_YAML,
 		ToSSH:    DEFAULT_TO_SSH,
 		ToJSON:   DEFAULT_TO_JSON,
+		Lossless: DEFAULT_LOSSLESS,
 		Src:      DEFAULT_SRC,
 		Dest:     DEFAULT_DEST,
 		ShowHelp: DEFAULT_HELP,
@@ -115,9 +119,15 @@ func CheckIOArgvValid(args Args) (result bool, desc string) {
 	}
 
 	// Check if src exists
-	_, err := os.Stat(args.Src)
+	info, err := os.Stat(args.Src)
 	if os.IsNotExist(err) {
 		return false, fmt.Sprintf("Error: Source path '%s' does not exist", args.Src)
+	}
+	if err != nil {
+		return false, fmt.Sprintf("Error: Can not inspect source path '%s': %v", args.Src, err)
+	}
+	if args.Lossless && info.IsDir() {
+		return false, "Lossless mode requires a single source file or standard input"
 	}
 
 	// allow empty dest

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -153,6 +153,12 @@ func TestCheckIOArgvValid(t *testing.T) {
 			wantResult: true,
 			wantDesc:   "",
 		},
+		{
+			name:       "Lossless mode rejects a source directory",
+			args:       Cmd.Args{Src: testDir, Lossless: true},
+			wantResult: false,
+			wantDesc:   "Lossless mode requires a single source file or standard input",
+		},
 	}
 
 	for _, tt := range tests {
@@ -259,11 +265,12 @@ func TestParseArgs(t *testing.T) {
 		},
 		{
 			name: "Set all flags",
-			args: []string{"-to-yaml", "-to-ssh", "-to-json", "-src", "source.txt", "-dest", "destination.txt", "-help"},
+			args: []string{"-to-yaml", "-to-ssh", "-to-json", "-lossless", "-src", "source.txt", "-dest", "destination.txt", "-help"},
 			expected: Cmd.Args{
 				ToYAML:   true,
 				ToSSH:    true,
 				ToJSON:   true,
+				Lossless: true,
 				Src:      "source.txt",
 				Dest:     "destination.txt",
 				ShowHelp: true,
@@ -349,6 +356,9 @@ func TestResetFlags(t *testing.T) {
 		t.Errorf("After ResetFlags(), ParseArgs() = %v, want %v", result, expected)
 	}
 	if result.ToYAML != expected.ToYAML {
+		t.Errorf("After ResetFlags(), ParseArgs() = %v, want %v", result, expected)
+	}
+	if result.Lossless != expected.Lossless {
 		t.Errorf("After ResetFlags(), ParseArgs() = %v, want %v", result, expected)
 	}
 }

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -22,6 +22,8 @@ const Usage = `Usage:
   ssh-config -to-yaml
   ssh-config -to-ssh
   ssh-config -to-json
+  ssh-config -lossless -to-yaml -src <SSH config file>
+  ssh-config -lossless -to-ssh -src <v3 YAML or JSON file>
   ssh-config -src <source file or directories path> -dest <destination file path>
   ssh-config -help
 `

--- a/internal/parser/lossless.go
+++ b/internal/parser/lossless.go
@@ -1,0 +1,76 @@
+package parser
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	Cmd "github.com/soulteary/ssh-config/v2/cmd"
+	"github.com/soulteary/ssh-config/v2/pkg/sshconfig"
+)
+
+// ProcessLossless converts SSH source or a v3 structured document without
+// routing it through the legacy map representation.
+func ProcessLossless(fileType, userInput string, args Cmd.Args) ([]byte, error) {
+	data := []byte(userInput)
+	schema, structured, err := decodeLosslessInput(fileType, data)
+	if err != nil {
+		return nil, err
+	}
+	if !structured {
+		document, err := sshconfig.Parse(data)
+		if err != nil {
+			return nil, err
+		}
+		schemaDocument, err := document.ToSchema("")
+		if err != nil {
+			return nil, err
+		}
+		schema = sshconfig.NewSchema(schemaDocument)
+	}
+
+	switch {
+	case args.ToYAML:
+		return sshconfig.MarshalSchemaYAML(schema)
+	case args.ToJSON:
+		return sshconfig.MarshalSchemaJSON(schema)
+	case args.ToSSH:
+		document, err := schema.Document("")
+		if err != nil {
+			return nil, err
+		}
+		return document.MarshalPreserve()
+	default:
+		return nil, nil
+	}
+}
+
+func decodeLosslessInput(fileType string, data []byte) (sshconfig.Schema, bool, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return sshconfig.Schema{}, false, nil
+	}
+
+	switch trimmed[0] {
+	case '{':
+		schema, err := sshconfig.UnmarshalSchemaJSON(data)
+		return schema, true, err
+	case '[':
+		schema, err := sshconfig.MigrateLegacyJSON(data, "")
+		return schema, true, err
+	}
+
+	if strings.EqualFold(fileType, "YAML") {
+		schema, schemaErr := sshconfig.UnmarshalSchemaYAML(data)
+		if schemaErr == nil {
+			return schema, true, nil
+		}
+		legacy, legacyErr := sshconfig.MigrateLegacyYAML(data, "")
+		if legacyErr == nil {
+			return legacy, true, nil
+		}
+		return sshconfig.Schema{}, true, fmt.Errorf("lossless input is neither v3 nor legacy YAML: v3: %v; legacy: %v", schemaErr, legacyErr)
+	}
+
+	return sshconfig.Schema{}, false, nil
+}

--- a/internal/parser/lossless_test.go
+++ b/internal/parser/lossless_test.go
@@ -1,0 +1,62 @@
+package parser_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	Cmd "github.com/soulteary/ssh-config/v2/cmd"
+	Parser "github.com/soulteary/ssh-config/v2/internal/parser"
+)
+
+func TestProcessLosslessSSHThroughStructuredFormats(t *testing.T) {
+	t.Parallel()
+	input := "# keep\r\nHost=example\r\n\tIdentityFile first\r\n\tIdentityFile second # backup\r\n"
+
+	yamlData, err := Parser.Process("TEXT", input, Cmd.Args{ToYAML: true, Lossless: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(yamlData), "schemaVersion: 3") || !strings.Contains(string(yamlData), "rawBase64:") {
+		t.Fatalf("lossless YAML does not contain the v3 envelope:\n%s", yamlData)
+	}
+	yamlBack, err := Parser.Process("YAML", string(yamlData), Cmd.Args{ToSSH: true, Lossless: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(yamlBack, []byte(input)) {
+		t.Fatalf("YAML round trip mismatch\n got: %q\nwant: %q", yamlBack, input)
+	}
+
+	jsonData, err := Parser.Process("TEXT", input, Cmd.Args{ToJSON: true, Lossless: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonBack, err := Parser.Process("YAML", string(jsonData), Cmd.Args{ToSSH: true, Lossless: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(jsonBack, []byte(input)) {
+		t.Fatalf("JSON round trip mismatch\n got: %q\nwant: %q", jsonBack, input)
+	}
+}
+
+func TestProcessLosslessMigratesLegacyJSON(t *testing.T) {
+	t.Parallel()
+	input := `[{"Name":"example","Data":{"User":"root"}}]`
+	got, err := Parser.Process("JSON", input, Cmd.Args{ToSSH: true, Lossless: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "Host example\n    User root\n" {
+		t.Fatalf("migrated output = %q", got)
+	}
+}
+
+func TestProcessLosslessRejectsInvalidStructuredInput(t *testing.T) {
+	t.Parallel()
+	_, err := Parser.Process("YAML", "schemaVersion: 9\ndocuments: []\n", Cmd.Args{ToSSH: true, Lossless: true})
+	if err == nil {
+		t.Fatal("invalid structured input was accepted")
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -25,6 +25,10 @@ import (
 )
 
 func Process(fileType string, userInput string, args Cmd.Args) ([]byte, error) {
+	if args.Lossless {
+		return ProcessLossless(fileType, userInput, args)
+	}
+
 	var hostConfigs []Define.HostConfig
 
 	switch strings.ToUpper(fileType) {

--- a/main.go
+++ b/main.go
@@ -18,12 +18,14 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
 	Cmd "github.com/soulteary/ssh-config/v2/cmd"
 	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
 	Parser "github.com/soulteary/ssh-config/v2/internal/parser"
+	"github.com/soulteary/ssh-config/v2/pkg/sshconfig"
 )
 
 type Dependencies struct {
@@ -32,7 +34,10 @@ type Dependencies struct {
 	Println               func(...interface{}) (n int, err error)
 	GetContent            func(string) ([]byte, error)
 	SaveFile              func(string, []byte) error
+	SaveLossless          func(string, []byte) error
 	GetUserInputFromStdin func() string
+	GetLosslessStdin      func() ([]byte, error)
+	WriteOutput           func([]byte) error
 	Process               func(string, string, Cmd.Args) ([]byte, error)
 	CheckUseStdin         func() bool
 	UserHomeDir           func() (string, error)
@@ -48,7 +53,16 @@ func Run(args Cmd.Args, deps Dependencies) error {
 	pipeMode := deps.CheckUseStdin()
 	var userInput string
 	if pipeMode {
-		userInput = deps.GetUserInputFromStdin()
+		if args.Lossless && deps.GetLosslessStdin != nil {
+			input, err := deps.GetLosslessStdin()
+			if err != nil {
+				deps.Println("Error reading stdin:", err)
+				return err
+			}
+			userInput = string(input)
+		} else {
+			userInput = deps.GetUserInputFromStdin()
+		}
 	} else {
 		isValid, notValidReason := Cmd.CheckIOArgvValid(args)
 		if !isValid {
@@ -72,14 +86,32 @@ func Run(args Cmd.Args, deps Dependencies) error {
 	}
 
 	if pipeMode {
-		deps.Println(string(result))
+		if args.Lossless && deps.WriteOutput != nil {
+			if err := deps.WriteOutput(result); err != nil {
+				deps.Println("Error writing output:", err)
+				return err
+			}
+		} else {
+			deps.Println(string(result))
+		}
 	} else {
 		if args.Dest == "" {
-			deps.Println(string(result))
+			if args.Lossless && deps.WriteOutput != nil {
+				if err := deps.WriteOutput(result); err != nil {
+					deps.Println("Error writing output:", err)
+					return err
+				}
+			} else {
+				deps.Println(string(result))
+			}
 			return nil
 		}
 
-		err := deps.SaveFile(args.Dest, result)
+		save := deps.SaveFile
+		if args.Lossless && deps.SaveLossless != nil {
+			save = deps.SaveLossless
+		}
+		err := save(args.Dest, result)
 		if err != nil {
 			deps.Println("Error saving file:", err)
 			return err
@@ -93,14 +125,22 @@ func Run(args Cmd.Args, deps Dependencies) error {
 
 func MainWithDependencies(exit func(int), userHomeDir func() (string, error)) {
 	deps := Dependencies{
-		StdinStat:             os.Stdin.Stat,
-		Exit:                  os.Exit,
-		Println:               fmt.Println,
-		GetContent:            Fn.GetPathContent,
-		SaveFile:              Fn.Save,
+		StdinStat:  os.Stdin.Stat,
+		Exit:       os.Exit,
+		Println:    fmt.Println,
+		GetContent: Fn.GetPathContent,
+		SaveFile:   Fn.Save,
+		SaveLossless: func(path string, data []byte) error {
+			return sshconfig.SaveAtomic(path, data, sshconfig.SaveOptions{PreserveMode: true})
+		},
 		GetUserInputFromStdin: Fn.GetUserInputFromStdin,
-		Process:               Parser.Process,
-		CheckUseStdin:         func() bool { return Cmd.CheckUseStdin(os.Stdin.Stat) },
+		GetLosslessStdin:      func() ([]byte, error) { return io.ReadAll(os.Stdin) },
+		WriteOutput: func(data []byte) error {
+			_, err := os.Stdout.Write(data)
+			return err
+		},
+		Process:       Parser.Process,
+		CheckUseStdin: func() bool { return Cmd.CheckUseStdin(os.Stdin.Stat) },
 	}
 	args := Cmd.ParseArgs()
 

--- a/main_test.go
+++ b/main_test.go
@@ -183,6 +183,61 @@ func TestRun(t *testing.T) {
 	}
 }
 
+func TestRunUsesAtomicSaverInLosslessMode(t *testing.T) {
+	source := path.Join(t.TempDir(), "input.yaml")
+	if err := os.WriteFile(source, []byte("schema"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	atomicCalled := false
+	err := Run(Cmd.Args{ToSSH: true, Lossless: true, Src: source, Dest: "config"}, Dependencies{
+		Println:       func(...interface{}) (int, error) { return 0, nil },
+		CheckUseStdin: func() bool { return false },
+		GetContent:    func(string) ([]byte, error) { return []byte("schema"), nil },
+		Process:       func(string, string, Cmd.Args) ([]byte, error) { return []byte("Host example\n"), nil },
+		SaveFile:      func(string, []byte) error { t.Fatal("legacy saver called"); return nil },
+		SaveLossless: func(string, []byte) error {
+			atomicCalled = true
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !atomicCalled {
+		t.Fatal("lossless saver was not called")
+	}
+}
+
+func TestRunLosslessPipePreservesInputAndOutputBytes(t *testing.T) {
+	input := []byte("Host=example\r\nIdentityFile first\r\nIdentityFile second")
+	var output []byte
+	err := Run(Cmd.Args{ToSSH: true, Lossless: true}, Dependencies{
+		Println:       func(...interface{}) (int, error) { return 0, nil },
+		CheckUseStdin: func() bool { return true },
+		GetUserInputFromStdin: func() string {
+			t.Fatal("line-oriented stdin reader called")
+			return ""
+		},
+		GetLosslessStdin: func() ([]byte, error) { return input, nil },
+		Process: func(_ string, got string, _ Cmd.Args) ([]byte, error) {
+			if !bytes.Equal([]byte(got), input) {
+				t.Fatalf("processor input = %q, want %q", got, input)
+			}
+			return []byte(got), nil
+		},
+		WriteOutput: func(data []byte) error {
+			output = append([]byte(nil), data...)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(output, input) {
+		t.Fatalf("stdout = %q, want %q", output, input)
+	}
+}
+
 func TestMainWithDependencies(t *testing.T) {
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()


### PR DESCRIPTION
## Summary

- add an opt-in `-lossless` CLI mode while retaining the v2 legacy formats as the default
- convert SSH source to v3 YAML/JSON and reconstruct SSH source without the legacy map representation
- import legacy YAML/JSON deterministically through the migration helpers
- preserve stdin and stdout bytes exactly instead of normalizing line endings or appending a newline
- use atomic destination replacement with existing-mode preservation
- reject directory input in lossless mode because concatenating files would destroy physical document boundaries
- document the workflow in English and Chinese

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./pkg/sshconfig`
- `git diff --check`

Full `go vet ./...` still reports the pre-existing malformed struct tag at `internal/parser/define.go:141`; this PR does not modify that field.

## Stack

Depends on #11, #12, #13, #14, #15, and #16. Merge this PR last.