### PR TITLE
feat: integrate the lossless SSH config stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ SSH Config Tool is a command-line utility for managing SSH configuration files. 
 - Supports reading configuration from files or standard input (stdin)
 - Supports output to files or standard output (stdout), creating parent folders when needed
 - Automatically detects the input format (YAML/JSON/SSH Config) and tidies trailing blank lines
+- Offers an opt-in lossless v3 format that preserves comments, ordering, repeated directives, quoting, line endings, and unknown directives
 
 ## Installation
 
@@ -82,6 +83,7 @@ cat /ssh/test.yaml | ssh-config -to-yaml
 - `-to-yaml, -to-json, -to-ssh`: Specify output format (yaml/json/config), only one output format can be specified at a time.
 - `-src`: Specify the original configuration file or directory to read from. When omitted, the tool scans `~/.ssh`.
 - `-dest`: Specify the path to save the configuration file. When omitted, the converted result is written to standard output.
+- `-lossless`: Use the lossless parser and v3 YAML/JSON schema. This mode accepts one source file or stdin and writes destination files atomically.
 - `-help`: View program command-line help
 
 ### Examples
@@ -109,6 +111,16 @@ ssh-config -to-json -src ~/.ssh/config -dest output.json
 ```bash
 cat input.conf | ssh-config -to-yaml > output.yaml
 ```
+
+5. Losslessly edit a configuration through the v3 YAML representation:
+
+```bash
+ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+# Edit directive fields in config.v3.yaml. Unchanged lines retain their exact bytes.
+ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+```
+
+The previous YAML/JSON formats remain the default for compatibility. Lossless mode can import them, but ordering and repeated values already discarded by a legacy map cannot be reconstructed.
 
 ## Development
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -15,6 +15,7 @@ SSH Config Tool 是一个用于管理 SSH 配置文件的命令行工具。它�
 - 支持从文件输入或标准输入(stdin)读取配置
 - 支持输出到文件或标准输出(stdout)
 - 自动检测输入格式(YAML/JSON/SSH Config)
+- 提供可选的 v3 无损格式，保留注释、顺序、重复指令、引号、换行符和未知指令
 
 ## 安装
 
@@ -75,6 +76,7 @@ cat /ssh/test.yaml | ssh-config -to-yaml
 - `-to-yaml, -to-json, -to-ssh`: 指定输出格式 (yaml/json/config)，同一时间，输出格式只能指定为一种。
 - `-src`: 指定要读取的原始配置文件，或配置目录
 - `-dest`: 指定要保存的配置文件路径
+- `-lossless`: 使用无损解析器和 v3 YAML/JSON 格式。此模式接受单个源文件或标准输入，并以原子方式写入目标文件。
 - `-help`: 查看程序命令行帮助
 
 ### 示例
@@ -96,6 +98,16 @@ ssh-config -to-json -src ~/.ssh/config -dest output.json
 ```bash
 cat input.conf | ssh-config -to-yaml > output.yaml
 ```
+
+4. 通过 v3 YAML 格式无损编辑配置：
+
+```bash
+ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+# 修改 config.v3.yaml 中的 directive 字段；未修改的行会保留原始字节。
+ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+```
+
+为保持兼容，默认仍使用原有 YAML/JSON 格式。无损模式能够导入旧格式，但无法恢复已经被旧 map 结构丢弃的顺序和重复值。
 
 ## 开发
 

--- a/cmd/argv.go
+++ b/cmd/argv.go
@@ -34,24 +34,27 @@ type Args struct {
 	ToYAML   bool
 	ToSSH    bool
 	ToJSON   bool
+	Lossless bool
 	Src      string
 	Dest     string
 	ShowHelp bool
 }
 
 const (
-	DEFAULT_TO_YAML = false
-	DEFAULT_TO_SSH  = false
-	DEFAULT_TO_JSON = false
-	DEFAULT_SRC     = ""
-	DEFAULT_DEST    = ""
-	DEFAULT_HELP    = false
+	DEFAULT_TO_YAML  = false
+	DEFAULT_TO_SSH   = false
+	DEFAULT_TO_JSON  = false
+	DEFAULT_LOSSLESS = false
+	DEFAULT_SRC      = ""
+	DEFAULT_DEST     = ""
+	DEFAULT_HELP     = false
 )
 
 func initFlags() {
 	flag.BoolVar(&args.ToYAML, "to-yaml", DEFAULT_TO_YAML, "Convert SSH config(Text/JSON) to YAML")
-	flag.BoolVar(&args.ToSSH, "to-ssh", DEFAULT_TO_SSH, "Convert SSH config(YAML/JSON) to YAML")
+	flag.BoolVar(&args.ToSSH, "to-ssh", DEFAULT_TO_SSH, "Convert SSH config(YAML/JSON) to SSH config")
 	flag.BoolVar(&args.ToJSON, "to-json", DEFAULT_TO_JSON, "Convert SSH config(YAML/Text) to JSON")
+	flag.BoolVar(&args.Lossless, "lossless", DEFAULT_LOSSLESS, "Use the lossless v3 parser and structured format")
 	flag.StringVar(&args.Src, "src", DEFAULT_SRC, "Source file or directories path, valid when using non-pipeline mode")
 	flag.StringVar(&args.Dest, "dest", DEFAULT_DEST, "Destination file path, valid when using non-pipeline mode")
 	flag.BoolVar(&args.ShowHelp, "help", DEFAULT_HELP, "Show help")
@@ -71,6 +74,7 @@ func ResetFlags() {
 		ToYAML:   DEFAULT_TO_YAML,
 		ToSSH:    DEFAULT_TO_SSH,
 		ToJSON:   DEFAULT_TO_JSON,
+		Lossless: DEFAULT_LOSSLESS,
 		Src:      DEFAULT_SRC,
 		Dest:     DEFAULT_DEST,
 		ShowHelp: DEFAULT_HELP,
@@ -115,9 +119,15 @@ func CheckIOArgvValid(args Args) (result bool, desc string) {
 	}
 
 	// Check if src exists
-	_, err := os.Stat(args.Src)
+	info, err := os.Stat(args.Src)
 	if os.IsNotExist(err) {
 		return false, fmt.Sprintf("Error: Source path '%s' does not exist", args.Src)
+	}
+	if err != nil {
+		return false, fmt.Sprintf("Error: Can not inspect source path '%s': %v", args.Src, err)
+	}
+	if args.Lossless && info.IsDir() {
+		return false, "Lossless mode requires a single source file or standard input"
 	}
 
 	// allow empty dest

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -153,6 +153,12 @@ func TestCheckIOArgvValid(t *testing.T) {
 			wantResult: true,
 			wantDesc:   "",
 		},
+		{
+			name:       "Lossless mode rejects a source directory",
+			args:       Cmd.Args{Src: testDir, Lossless: true},
+			wantResult: false,
+			wantDesc:   "Lossless mode requires a single source file or standard input",
+		},
 	}
 
 	for _, tt := range tests {
@@ -259,11 +265,12 @@ func TestParseArgs(t *testing.T) {
 		},
 		{
 			name: "Set all flags",
-			args: []string{"-to-yaml", "-to-ssh", "-to-json", "-src", "source.txt", "-dest", "destination.txt", "-help"},
+			args: []string{"-to-yaml", "-to-ssh", "-to-json", "-lossless", "-src", "source.txt", "-dest", "destination.txt", "-help"},
 			expected: Cmd.Args{
 				ToYAML:   true,
 				ToSSH:    true,
 				ToJSON:   true,
+				Lossless: true,
 				Src:      "source.txt",
 				Dest:     "destination.txt",
 				ShowHelp: true,
@@ -349,6 +356,9 @@ func TestResetFlags(t *testing.T) {
 		t.Errorf("After ResetFlags(), ParseArgs() = %v, want %v", result, expected)
 	}
 	if result.ToYAML != expected.ToYAML {
+		t.Errorf("After ResetFlags(), ParseArgs() = %v, want %v", result, expected)
+	}
+	if result.Lossless != expected.Lossless {
 		t.Errorf("After ResetFlags(), ParseArgs() = %v, want %v", result, expected)
 	}
 }

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -22,6 +22,8 @@ const Usage = `Usage:
   ssh-config -to-yaml
   ssh-config -to-ssh
   ssh-config -to-json
+  ssh-config -lossless -to-yaml -src <SSH config file>
+  ssh-config -lossless -to-ssh -src <v3 YAML or JSON file>
   ssh-config -src <source file or directories path> -dest <destination file path>
   ssh-config -help
 `

--- a/internal/parser/lossless.go
+++ b/internal/parser/lossless.go
@@ -1,0 +1,76 @@
+package parser
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	Cmd "github.com/soulteary/ssh-config/v2/cmd"
+	"github.com/soulteary/ssh-config/v2/pkg/sshconfig"
+)
+
+// ProcessLossless converts SSH source or a v3 structured document without
+// routing it through the legacy map representation.
+func ProcessLossless(fileType, userInput string, args Cmd.Args) ([]byte, error) {
+	data := []byte(userInput)
+	schema, structured, err := decodeLosslessInput(fileType, data)
+	if err != nil {
+		return nil, err
+	}
+	if !structured {
+		document, err := sshconfig.Parse(data)
+		if err != nil {
+			return nil, err
+		}
+		schemaDocument, err := document.ToSchema("")
+		if err != nil {
+			return nil, err
+		}
+		schema = sshconfig.NewSchema(schemaDocument)
+	}
+
+	switch {
+	case args.ToYAML:
+		return sshconfig.MarshalSchemaYAML(schema)
+	case args.ToJSON:
+		return sshconfig.MarshalSchemaJSON(schema)
+	case args.ToSSH:
+		document, err := schema.Document("")
+		if err != nil {
+			return nil, err
+		}
+		return document.MarshalPreserve()
+	default:
+		return nil, nil
+	}
+}
+
+func decodeLosslessInput(fileType string, data []byte) (sshconfig.Schema, bool, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return sshconfig.Schema{}, false, nil
+	}
+
+	switch trimmed[0] {
+	case '{':
+		schema, err := sshconfig.UnmarshalSchemaJSON(data)
+		return schema, true, err
+	case '[':
+		schema, err := sshconfig.MigrateLegacyJSON(data, "")
+		return schema, true, err
+	}
+
+	if strings.EqualFold(fileType, "YAML") {
+		schema, schemaErr := sshconfig.UnmarshalSchemaYAML(data)
+		if schemaErr == nil {
+			return schema, true, nil
+		}
+		legacy, legacyErr := sshconfig.MigrateLegacyYAML(data, "")
+		if legacyErr == nil {
+			return legacy, true, nil
+		}
+		return sshconfig.Schema{}, true, fmt.Errorf("lossless input is neither v3 nor legacy YAML: v3: %v; legacy: %v", schemaErr, legacyErr)
+	}
+
+	return sshconfig.Schema{}, false, nil
+}

--- a/internal/parser/lossless_test.go
+++ b/internal/parser/lossless_test.go
@@ -1,0 +1,62 @@
+package parser_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	Cmd "github.com/soulteary/ssh-config/v2/cmd"
+	Parser "github.com/soulteary/ssh-config/v2/internal/parser"
+)
+
+func TestProcessLosslessSSHThroughStructuredFormats(t *testing.T) {
+	t.Parallel()
+	input := "# keep\r\nHost=example\r\n\tIdentityFile first\r\n\tIdentityFile second # backup\r\n"
+
+	yamlData, err := Parser.Process("TEXT", input, Cmd.Args{ToYAML: true, Lossless: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(yamlData), "schemaVersion: 3") || !strings.Contains(string(yamlData), "rawBase64:") {
+		t.Fatalf("lossless YAML does not contain the v3 envelope:\n%s", yamlData)
+	}
+	yamlBack, err := Parser.Process("YAML", string(yamlData), Cmd.Args{ToSSH: true, Lossless: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(yamlBack, []byte(input)) {
+		t.Fatalf("YAML round trip mismatch\n got: %q\nwant: %q", yamlBack, input)
+	}
+
+	jsonData, err := Parser.Process("TEXT", input, Cmd.Args{ToJSON: true, Lossless: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	jsonBack, err := Parser.Process("YAML", string(jsonData), Cmd.Args{ToSSH: true, Lossless: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(jsonBack, []byte(input)) {
+		t.Fatalf("JSON round trip mismatch\n got: %q\nwant: %q", jsonBack, input)
+	}
+}
+
+func TestProcessLosslessMigratesLegacyJSON(t *testing.T) {
+	t.Parallel()
+	input := `[{"Name":"example","Data":{"User":"root"}}]`
+	got, err := Parser.Process("JSON", input, Cmd.Args{ToSSH: true, Lossless: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "Host example\n    User root\n" {
+		t.Fatalf("migrated output = %q", got)
+	}
+}
+
+func TestProcessLosslessRejectsInvalidStructuredInput(t *testing.T) {
+	t.Parallel()
+	_, err := Parser.Process("YAML", "schemaVersion: 9\ndocuments: []\n", Cmd.Args{ToSSH: true, Lossless: true})
+	if err == nil {
+		t.Fatal("invalid structured input was accepted")
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -25,6 +25,10 @@ import (
 )
 
 func Process(fileType string, userInput string, args Cmd.Args) ([]byte, error) {
+	if args.Lossless {
+		return ProcessLossless(fileType, userInput, args)
+	}
+
 	var hostConfigs []Define.HostConfig
 
 	switch strings.ToUpper(fileType) {

--- a/main.go
+++ b/main.go
@@ -18,12 +18,14 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
 	Cmd "github.com/soulteary/ssh-config/v2/cmd"
 	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
 	Parser "github.com/soulteary/ssh-config/v2/internal/parser"
+	"github.com/soulteary/ssh-config/v2/pkg/sshconfig"
 )
 
 type Dependencies struct {
@@ -32,7 +34,10 @@ type Dependencies struct {
 	Println               func(...interface{}) (n int, err error)
 	GetContent            func(string) ([]byte, error)
 	SaveFile              func(string, []byte) error
+	SaveLossless          func(string, []byte) error
 	GetUserInputFromStdin func() string
+	GetLosslessStdin      func() ([]byte, error)
+	WriteOutput           func([]byte) error
 	Process               func(string, string, Cmd.Args) ([]byte, error)
 	CheckUseStdin         func() bool
 	UserHomeDir           func() (string, error)
@@ -48,7 +53,16 @@ func Run(args Cmd.Args, deps Dependencies) error {
 	pipeMode := deps.CheckUseStdin()
 	var userInput string
 	if pipeMode {
-		userInput = deps.GetUserInputFromStdin()
+		if args.Lossless && deps.GetLosslessStdin != nil {
+			input, err := deps.GetLosslessStdin()
+			if err != nil {
+				deps.Println("Error reading stdin:", err)
+				return err
+			}
+			userInput = string(input)
+		} else {
+			userInput = deps.GetUserInputFromStdin()
+		}
 	} else {
 		isValid, notValidReason := Cmd.CheckIOArgvValid(args)
 		if !isValid {
@@ -72,14 +86,32 @@ func Run(args Cmd.Args, deps Dependencies) error {
 	}
 
 	if pipeMode {
-		deps.Println(string(result))
+		if args.Lossless && deps.WriteOutput != nil {
+			if err := deps.WriteOutput(result); err != nil {
+				deps.Println("Error writing output:", err)
+				return err
+			}
+		} else {
+			deps.Println(string(result))
+		}
 	} else {
 		if args.Dest == "" {
-			deps.Println(string(result))
+			if args.Lossless && deps.WriteOutput != nil {
+				if err := deps.WriteOutput(result); err != nil {
+					deps.Println("Error writing output:", err)
+					return err
+				}
+			} else {
+				deps.Println(string(result))
+			}
 			return nil
 		}
 
-		err := deps.SaveFile(args.Dest, result)
+		save := deps.SaveFile
+		if args.Lossless && deps.SaveLossless != nil {
+			save = deps.SaveLossless
+		}
+		err := save(args.Dest, result)
 		if err != nil {
 			deps.Println("Error saving file:", err)
 			return err
@@ -93,14 +125,22 @@ func Run(args Cmd.Args, deps Dependencies) error {
 
 func MainWithDependencies(exit func(int), userHomeDir func() (string, error)) {
 	deps := Dependencies{
-		StdinStat:             os.Stdin.Stat,
-		Exit:                  os.Exit,
-		Println:               fmt.Println,
-		GetContent:            Fn.GetPathContent,
-		SaveFile:              Fn.Save,
+		StdinStat:  os.Stdin.Stat,
+		Exit:       os.Exit,
+		Println:    fmt.Println,
+		GetContent: Fn.GetPathContent,
+		SaveFile:   Fn.Save,
+		SaveLossless: func(path string, data []byte) error {
+			return sshconfig.SaveAtomic(path, data, sshconfig.SaveOptions{PreserveMode: true})
+		},
 		GetUserInputFromStdin: Fn.GetUserInputFromStdin,
-		Process:               Parser.Process,
-		CheckUseStdin:         func() bool { return Cmd.CheckUseStdin(os.Stdin.Stat) },
+		GetLosslessStdin:      func() ([]byte, error) { return io.ReadAll(os.Stdin) },
+		WriteOutput: func(data []byte) error {
+			_, err := os.Stdout.Write(data)
+			return err
+		},
+		Process:       Parser.Process,
+		CheckUseStdin: func() bool { return Cmd.CheckUseStdin(os.Stdin.Stat) },
 	}
 	args := Cmd.ParseArgs()
 

--- a/main_test.go
+++ b/main_test.go
@@ -183,6 +183,61 @@ func TestRun(t *testing.T) {
 	}
 }
 
+func TestRunUsesAtomicSaverInLosslessMode(t *testing.T) {
+	source := path.Join(t.TempDir(), "input.yaml")
+	if err := os.WriteFile(source, []byte("schema"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	atomicCalled := false
+	err := Run(Cmd.Args{ToSSH: true, Lossless: true, Src: source, Dest: "config"}, Dependencies{
+		Println:       func(...interface{}) (int, error) { return 0, nil },
+		CheckUseStdin: func() bool { return false },
+		GetContent:    func(string) ([]byte, error) { return []byte("schema"), nil },
+		Process:       func(string, string, Cmd.Args) ([]byte, error) { return []byte("Host example\n"), nil },
+		SaveFile:      func(string, []byte) error { t.Fatal("legacy saver called"); return nil },
+		SaveLossless: func(string, []byte) error {
+			atomicCalled = true
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !atomicCalled {
+		t.Fatal("lossless saver was not called")
+	}
+}
+
+func TestRunLosslessPipePreservesInputAndOutputBytes(t *testing.T) {
+	input := []byte("Host=example\r\nIdentityFile first\r\nIdentityFile second")
+	var output []byte
+	err := Run(Cmd.Args{ToSSH: true, Lossless: true}, Dependencies{
+		Println:       func(...interface{}) (int, error) { return 0, nil },
+		CheckUseStdin: func() bool { return true },
+		GetUserInputFromStdin: func() string {
+			t.Fatal("line-oriented stdin reader called")
+			return ""
+		},
+		GetLosslessStdin: func() ([]byte, error) { return input, nil },
+		Process: func(_ string, got string, _ Cmd.Args) ([]byte, error) {
+			if !bytes.Equal([]byte(got), input) {
+				t.Fatalf("processor input = %q, want %q", got, input)
+			}
+			return []byte(got), nil
+		},
+		WriteOutput: func(data []byte) error {
+			output = append([]byte(nil), data...)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(output, input) {
+		t.Fatalf("stdout = %q, want %q", output, input)
+	}
+}
+
 func TestMainWithDependencies(t *testing.T) {
 	oldArgs := os.Args
 	defer func() { os.Args = oldArgs }()

--- a/pkg/sshconfig/document.go
+++ b/pkg/sshconfig/document.go
@@ -72,6 +72,7 @@ type Node struct {
 	Kind      NodeKind
 	Span      Span
 	Directive *Directive
+	original  *Directive
 }
 
 // Diagnostic records a recoverable syntax problem. Lossless parsing keeps
@@ -87,6 +88,9 @@ type Document struct {
 	nodes       []Node
 	diagnostics []Diagnostic
 	lineEnding  string
+	replacement map[NodeID][]byte
+	removed     map[NodeID]bool
+	nextID      NodeID
 }
 
 // Bytes returns an independent copy of the original document bytes.

--- a/pkg/sshconfig/edit.go
+++ b/pkg/sshconfig/edit.go
@@ -1,0 +1,188 @@
+package sshconfig
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// ReplaceDirective replaces one directive while retaining the original
+// indentation, inline comment, and line ending. The rest of the document is
+// not reformatted.
+func (d *Document) ReplaceDirective(id NodeID, keyword string, arguments ...string) error {
+	if d == nil {
+		return fmt.Errorf("sshconfig: nil document")
+	}
+	if keyword == "" {
+		return fmt.Errorf("sshconfig: directive keyword is empty")
+	}
+	index := d.nodeIndex(id)
+	if index < 0 {
+		return fmt.Errorf("sshconfig: node %d not found", id)
+	}
+	node := &d.nodes[index]
+	if node.original == nil {
+		return fmt.Errorf("sshconfig: node %d is not a source directive", id)
+	}
+	d.replacement[id] = d.renderReplacement(*node, keyword, arguments)
+	node.Kind = NodeDirective
+	node.Directive = syntheticDirective(keyword, arguments)
+	d.removed[id] = false
+	return nil
+}
+
+// RemoveNode removes exactly one syntax node. Repeated directives and other
+// nodes with the same keyword are unaffected.
+func (d *Document) RemoveNode(id NodeID) error {
+	if d == nil {
+		return fmt.Errorf("sshconfig: nil document")
+	}
+	if d.nodeIndex(id) < 0 {
+		return fmt.Errorf("sshconfig: node %d not found", id)
+	}
+	d.removed[id] = true
+	return nil
+}
+
+// InsertDirectiveAfter inserts a new directive after an existing node and
+// returns its stable node identifier.
+func (d *Document) InsertDirectiveAfter(after NodeID, keyword string, arguments ...string) (NodeID, error) {
+	if d == nil {
+		return 0, fmt.Errorf("sshconfig: nil document")
+	}
+	if keyword == "" {
+		return 0, fmt.Errorf("sshconfig: directive keyword is empty")
+	}
+	index := d.nodeIndex(after)
+	if index < 0 {
+		return 0, fmt.Errorf("sshconfig: node %d not found", after)
+	}
+	raw := d.renderNewDirective(keyword, arguments)
+	if !d.nodeHasLineEnding(d.nodes[index]) {
+		raw = append([]byte(d.Newline()), raw...)
+	}
+	id := d.nextID
+	d.nextID++
+	node := Node{ID: id, Kind: NodeDirective, Directive: syntheticDirective(keyword, arguments)}
+	d.nodes = append(d.nodes, Node{})
+	copy(d.nodes[index+2:], d.nodes[index+1:])
+	d.nodes[index+1] = node
+	d.replacement[id] = raw
+	return id, nil
+}
+
+// AppendDirective appends a directive to the end of a document.
+func (d *Document) AppendDirective(keyword string, arguments ...string) (NodeID, error) {
+	if d == nil {
+		return 0, fmt.Errorf("sshconfig: nil document")
+	}
+	if keyword == "" {
+		return 0, fmt.Errorf("sshconfig: directive keyword is empty")
+	}
+	raw := d.renderNewDirective(keyword, arguments)
+	for i := len(d.nodes) - 1; i >= 0; i-- {
+		if d.removed[d.nodes[i].ID] {
+			continue
+		}
+		if !d.nodeHasLineEnding(d.nodes[i]) {
+			raw = append([]byte(d.Newline()), raw...)
+		}
+		break
+	}
+	id := d.nextID
+	d.nextID++
+	d.nodes = append(d.nodes, Node{
+		ID:        id,
+		Kind:      NodeDirective,
+		Directive: syntheticDirective(keyword, arguments),
+	})
+	d.replacement[id] = raw
+	return id, nil
+}
+
+func (d *Document) nodeIndex(id NodeID) int {
+	for i := range d.nodes {
+		if d.nodes[i].ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func (d *Document) nodeHasLineEnding(node Node) bool {
+	if raw, ok := d.replacement[node.ID]; ok {
+		return bytes.HasSuffix(raw, []byte("\n")) || bytes.HasSuffix(raw, []byte("\r"))
+	}
+	if node.original != nil {
+		return node.original.LineEnding.End > node.original.LineEnding.Start
+	}
+	return false
+}
+
+func (d *Document) renderReplacement(node Node, keyword string, arguments []string) []byte {
+	original := node.original
+	var out bytes.Buffer
+	out.Write(d.source[node.Span.Start:original.Keyword.Span.Start])
+	out.WriteString(keyword)
+	separator := d.source[original.Separator.Start:original.Separator.End]
+	if len(separator) == 0 {
+		separator = []byte(" ")
+	}
+	if len(arguments) > 0 {
+		out.Write(separator)
+		writeArguments(&out, arguments)
+	}
+	if original.Comment != nil {
+		out.WriteByte(' ')
+		out.Write(d.source[original.Comment.Span.Start:original.Comment.Span.End])
+	}
+	out.Write(d.source[original.LineEnding.Start:original.LineEnding.End])
+	return out.Bytes()
+}
+
+func (d *Document) renderNewDirective(keyword string, arguments []string) []byte {
+	var out bytes.Buffer
+	out.WriteString(keyword)
+	if len(arguments) > 0 {
+		out.WriteByte(' ')
+		writeArguments(&out, arguments)
+	}
+	out.WriteString(d.Newline())
+	return out.Bytes()
+}
+
+func writeArguments(out *bytes.Buffer, arguments []string) {
+	for i, argument := range arguments {
+		if i > 0 {
+			out.WriteByte(' ')
+		}
+		out.WriteString(quoteArgument(argument))
+	}
+}
+
+func quoteArgument(argument string) string {
+	if argument != "" && !strings.ContainsAny(argument, " \t\r\n#\\\"'") {
+		return argument
+	}
+	var out strings.Builder
+	out.WriteByte('"')
+	for _, ch := range argument {
+		if ch == '\\' || ch == '"' {
+			out.WriteByte('\\')
+		}
+		out.WriteRune(ch)
+	}
+	out.WriteByte('"')
+	return out.String()
+}
+
+func syntheticDirective(keyword string, arguments []string) *Directive {
+	parsed := make([]Argument, 0, len(arguments))
+	for _, argument := range arguments {
+		parsed = append(parsed, Argument{Value: argument})
+	}
+	return &Directive{
+		KeywordValue: strings.ToLower(keyword),
+		Arguments:    parsed,
+	}
+}

--- a/pkg/sshconfig/include.go
+++ b/pkg/sshconfig/include.go
@@ -1,0 +1,223 @@
+package sshconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const defaultIncludeDepth = 16
+
+// ResolveOptions controls OpenSSH Include path expansion.
+type ResolveOptions struct {
+	// MaxDepth defaults to OpenSSH's READCONF_MAX_DEPTH value of 16.
+	MaxDepth int
+	// RelativeBase is used for non-absolute Include paths. When empty,
+	// UserHome/.ssh is used if UserHome is set, otherwise the entry file's
+	// directory is used.
+	RelativeBase string
+	UserHome     string
+	// Environment enables ${NAME} expansion using this explicit map. A nil
+	// map disables environment expansion.
+	Environment map[string]string
+	// Tokens supplies OpenSSH-style percent token values, for example 'h'.
+	Tokens map[byte]string
+	// CheckPermissions rejects files writable by group or others.
+	CheckPermissions bool
+}
+
+// ResolvedFile is one parsed file in an Include graph.
+type ResolvedFile struct {
+	Path     string
+	Document *Document
+}
+
+// IncludeEdge records one Include directive and its lexically ordered files.
+type IncludeEdge struct {
+	FromPath string
+	NodeID   NodeID
+	Pattern  string
+	Targets  []string
+}
+
+// DocumentGraph retains all source documents and Include relationships.
+type DocumentGraph struct {
+	Entry string
+	Files map[string]*ResolvedFile
+	Edges []IncludeEdge
+	// Order records traversal order, including repeated non-recursive includes.
+	Order []string
+}
+
+// ResolveIncludes parses entry and recursively builds its Include graph.
+// Include directives are retained in their source documents.
+func ResolveIncludes(entry string, options ResolveOptions) (*DocumentGraph, error) {
+	if entry == "" {
+		return nil, fmt.Errorf("sshconfig: include entry path is empty")
+	}
+	absolute, err := filepath.Abs(entry)
+	if err != nil {
+		return nil, fmt.Errorf("sshconfig: resolve entry path: %w", err)
+	}
+	absolute = filepath.Clean(absolute)
+	if options.MaxDepth <= 0 {
+		options.MaxDepth = defaultIncludeDepth
+	}
+	if options.RelativeBase == "" {
+		if options.UserHome != "" {
+			options.RelativeBase = filepath.Join(options.UserHome, ".ssh")
+		} else {
+			options.RelativeBase = filepath.Dir(absolute)
+		}
+	}
+	graph := &DocumentGraph{
+		Entry: absolute,
+		Files: make(map[string]*ResolvedFile),
+	}
+	if err := graph.resolveFile(absolute, options, 0, make(map[string]bool)); err != nil {
+		return nil, err
+	}
+	return graph, nil
+}
+
+func (g *DocumentGraph) resolveFile(path string, options ResolveOptions, depth int, stack map[string]bool) error {
+	path = filepath.Clean(path)
+	if depth > options.MaxDepth {
+		return fmt.Errorf("sshconfig: include depth exceeds %d at %s", options.MaxDepth, path)
+	}
+	if stack[path] {
+		return fmt.Errorf("sshconfig: recursive include cycle at %s", path)
+	}
+	if options.CheckPermissions {
+		if err := checkIncludePermissions(path); err != nil {
+			return err
+		}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("sshconfig: read included file %s: %w", path, err)
+	}
+	doc, err := Parse(data)
+	if err != nil {
+		return fmt.Errorf("sshconfig: parse included file %s: %w", path, err)
+	}
+	if _, exists := g.Files[path]; !exists {
+		g.Files[path] = &ResolvedFile{Path: path, Document: doc}
+	}
+	g.Order = append(g.Order, path)
+	stack[path] = true
+	defer delete(stack, path)
+
+	for _, node := range doc.nodes {
+		if node.Directive == nil || node.Directive.KeywordValue != "include" {
+			continue
+		}
+		for _, argument := range node.Directive.Arguments {
+			pattern, err := expandIncludePattern(argument.Value, options)
+			if err != nil {
+				return fmt.Errorf("sshconfig: %s:%d: include %q: %w", path, argument.Position.Line, argument.Value, err)
+			}
+			if !filepath.IsAbs(pattern) {
+				pattern = filepath.Join(options.RelativeBase, pattern)
+			}
+			matches, err := filepath.Glob(filepath.Clean(pattern))
+			if err != nil {
+				return fmt.Errorf("sshconfig: %s:%d: invalid include pattern %q: %w", path, argument.Position.Line, pattern, err)
+			}
+			sort.Strings(matches)
+			edge := IncludeEdge{
+				FromPath: path,
+				NodeID:   node.ID,
+				Pattern:  argument.Value,
+				Targets:  append([]string(nil), matches...),
+			}
+			g.Edges = append(g.Edges, edge)
+			for _, match := range matches {
+				if err := g.resolveFile(match, options, depth+1, stack); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func expandIncludePattern(pattern string, options ResolveOptions) (string, error) {
+	var err error
+	if options.Environment != nil {
+		pattern, err = expandEnvironment(pattern, options.Environment)
+		if err != nil {
+			return "", err
+		}
+	}
+	pattern, err = expandPercentTokens(pattern, options.Tokens)
+	if err != nil {
+		return "", err
+	}
+	if pattern == "~" || strings.HasPrefix(pattern, "~/") || strings.HasPrefix(pattern, `~\`) {
+		if options.UserHome == "" {
+			return "", fmt.Errorf("cannot expand ~ without UserHome")
+		}
+		if pattern == "~" {
+			pattern = options.UserHome
+		} else {
+			pattern = filepath.Join(options.UserHome, pattern[2:])
+		}
+	}
+	return pattern, nil
+}
+
+func expandEnvironment(value string, environment map[string]string) (string, error) {
+	var missing string
+	expanded := os.Expand(value, func(name string) string {
+		result, ok := environment[name]
+		if !ok && missing == "" {
+			missing = name
+		}
+		return result
+	})
+	if missing != "" {
+		return "", fmt.Errorf("environment variable %s is not set", missing)
+	}
+	return expanded, nil
+}
+
+func expandPercentTokens(value string, tokens map[byte]string) (string, error) {
+	var out strings.Builder
+	for i := 0; i < len(value); i++ {
+		if value[i] != '%' {
+			out.WriteByte(value[i])
+			continue
+		}
+		if i+1 >= len(value) {
+			return "", fmt.Errorf("trailing %% token")
+		}
+		i++
+		if value[i] == '%' {
+			out.WriteByte('%')
+			continue
+		}
+		replacement, ok := tokens[value[i]]
+		if !ok {
+			return "", fmt.Errorf("unsupported %%%c token", value[i])
+		}
+		out.WriteString(replacement)
+	}
+	return out.String(), nil
+}
+
+func checkIncludePermissions(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("sshconfig: inspect included file %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("sshconfig: included path %s is not a regular file", path)
+	}
+	if info.Mode().Perm()&0022 != 0 {
+		return fmt.Errorf("sshconfig: bad permissions on %s: mode %o is writable by group or others", path, info.Mode().Perm())
+	}
+	return nil
+}

--- a/pkg/sshconfig/include_test.go
+++ b/pkg/sshconfig/include_test.go
@@ -1,0 +1,144 @@
+package sshconfig
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestResolveIncludesLexicalOrderAndContext(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	includeDirectory := filepath.Join(directory, "config.d")
+	if err := os.Mkdir(includeDirectory, 0700); err != nil {
+		t.Fatal(err)
+	}
+	writeTestConfig(t, filepath.Join(directory, "config"), "Host example\n  Include config.d/*\nMatch host internal\n  Include missing/*\n")
+	writeTestConfig(t, filepath.Join(includeDirectory, "20-second"), "Host second\n")
+	writeTestConfig(t, filepath.Join(includeDirectory, "10-first"), "Host first\n")
+
+	graph, err := ResolveIncludes(filepath.Join(directory, "config"), ResolveOptions{RelativeBase: directory})
+	if err != nil {
+		t.Fatalf("ResolveIncludes() error = %v", err)
+	}
+	wantOrder := []string{
+		filepath.Join(directory, "config"),
+		filepath.Join(includeDirectory, "10-first"),
+		filepath.Join(includeDirectory, "20-second"),
+	}
+	if !reflect.DeepEqual(graph.Order, wantOrder) {
+		t.Fatalf("order = %v, want %v", graph.Order, wantOrder)
+	}
+	if len(graph.Edges) != 2 || len(graph.Edges[1].Targets) != 0 {
+		t.Fatalf("edges = %#v", graph.Edges)
+	}
+	entry := graph.Files[graph.Entry].Document
+	got, _ := entry.MarshalPreserve()
+	want, _ := os.ReadFile(graph.Entry)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatal("resolving includes changed the entry document")
+	}
+}
+
+func TestResolveIncludesExpansions(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	sshDirectory := filepath.Join(directory, ".ssh")
+	if err := os.Mkdir(sshDirectory, 0700); err != nil {
+		t.Fatal(err)
+	}
+	entry := filepath.Join(sshDirectory, "config")
+	writeTestConfig(t, entry, "Include ~/hosts/${PROFILE}/%h.conf\n")
+	targetDirectory := filepath.Join(directory, "hosts", "work")
+	if err := os.MkdirAll(targetDirectory, 0700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(targetDirectory, "server.conf")
+	writeTestConfig(t, target, "Host server\n")
+
+	graph, err := ResolveIncludes(entry, ResolveOptions{
+		UserHome:    directory,
+		Environment: map[string]string{"PROFILE": "work"},
+		Tokens:      map[byte]string{'h': "server"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveIncludes() error = %v", err)
+	}
+	if len(graph.Order) != 2 || graph.Order[1] != target {
+		t.Fatalf("order = %v", graph.Order)
+	}
+}
+
+func TestResolveIncludesCycleAndDepth(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	first := filepath.Join(directory, "first")
+	second := filepath.Join(directory, "second")
+	writeTestConfig(t, first, "Include second\n")
+	writeTestConfig(t, second, "Include first\n")
+	_, err := ResolveIncludes(first, ResolveOptions{RelativeBase: directory})
+	if err == nil || !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("cycle error = %v", err)
+	}
+
+	writeTestConfig(t, second, "Host second\n")
+	_, err = ResolveIncludes(first, ResolveOptions{RelativeBase: directory, MaxDepth: 0})
+	if err != nil {
+		t.Fatalf("default depth error = %v", err)
+	}
+	_, err = ResolveIncludes(first, ResolveOptions{RelativeBase: directory, MaxDepth: -1})
+	if err != nil {
+		t.Fatalf("negative default depth error = %v", err)
+	}
+
+	third := filepath.Join(directory, "third")
+	writeTestConfig(t, second, "Include third\n")
+	writeTestConfig(t, third, "Host third\n")
+	_, err = ResolveIncludes(first, ResolveOptions{RelativeBase: directory, MaxDepth: 1})
+	if err == nil || !strings.Contains(err.Error(), "depth") {
+		t.Fatalf("depth error = %v", err)
+	}
+}
+
+func TestResolveIncludesPermissionCheck(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not portable to Windows")
+	}
+	t.Parallel()
+	directory := t.TempDir()
+	entry := filepath.Join(directory, "config")
+	writeTestConfig(t, entry, "Host example\n")
+	if err := os.Chmod(entry, 0666); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ResolveIncludes(entry, ResolveOptions{CheckPermissions: true})
+	if err == nil || !strings.Contains(err.Error(), "bad permissions") {
+		t.Fatalf("permission error = %v", err)
+	}
+}
+
+func TestResolveIncludesExpansionErrors(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	entry := filepath.Join(directory, "config")
+	writeTestConfig(t, entry, "Include ${MISSING}/%x\n")
+	_, err := ResolveIncludes(entry, ResolveOptions{Environment: map[string]string{}, Tokens: map[byte]string{}})
+	if err == nil || !strings.Contains(err.Error(), "MISSING") {
+		t.Fatalf("environment error = %v", err)
+	}
+	writeTestConfig(t, entry, "Include %x\n")
+	_, err = ResolveIncludes(entry, ResolveOptions{Tokens: map[byte]string{}})
+	if err == nil || !strings.Contains(err.Error(), "%x") {
+		t.Fatalf("token error = %v", err)
+	}
+}
+
+func writeTestConfig(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/sshconfig/keywords.go
+++ b/pkg/sshconfig/keywords.go
@@ -1,0 +1,85 @@
+package sshconfig
+
+import "strings"
+
+// KeywordStatus describes how the OpenSSH client treats a directive name.
+type KeywordStatus uint8
+
+const (
+	KeywordSupported KeywordStatus = iota
+	KeywordIgnored
+	KeywordDeprecated
+	KeywordUnsupported
+	KeywordPlatformDependent
+)
+
+// KeywordInfo describes an OpenSSH client configuration keyword.
+type KeywordInfo struct {
+	Name   string
+	Status KeywordStatus
+}
+
+// The registry follows openssh-portable readconf.c as of OpenBSD revision
+// 1.415 (2026-07-21). It is data derived from the public keyword table, not a
+// translation of OpenSSH's evaluator.
+var keywordRegistry = buildKeywordRegistry()
+
+// LookupKeyword performs a case-insensitive OpenSSH keyword lookup.
+func LookupKeyword(name string) (KeywordInfo, bool) {
+	info, ok := keywordRegistry[strings.ToLower(name)]
+	return info, ok
+}
+
+func buildKeywordRegistry() map[string]KeywordInfo {
+	registry := make(map[string]KeywordInfo)
+	add := func(status KeywordStatus, names string) {
+		for _, name := range strings.Fields(names) {
+			registry[name] = KeywordInfo{Name: name, Status: status}
+		}
+	}
+
+	add(KeywordIgnored, `
+		protocol
+	`)
+	add(KeywordDeprecated, `
+		cipher fallbacktorsh globalknownhostsfile2 rhostsauthentication
+		userknownhostsfile2 useroaming usersh useprivilegedport
+	`)
+	add(KeywordUnsupported, `
+		afstokenpassing kerberosauthentication kerberostgtpassing
+		rsaauthentication rhostsrsaauthentication compressionlevel
+	`)
+	add(KeywordPlatformDependent, `
+		gssapiauthentication gssapidelegatecredentials pkcs11provider
+		smartcarddevice
+	`)
+	add(KeywordSupported, `
+		addkeystoagent addressfamily batchmode bindaddress bindinterface
+		canonicaldomains canonicalizefallbacklocal canonicalizehostname
+		canonicalizemaxdots canonicalizepermittedcnames casignaturealgorithms
+		certificatefile challengeresponseauthentication channeltimeout checkhostip
+		ciphers clearallforwardings compression connectionattempts connecttimeout
+		controlmaster controlpath controlpersist dsaauthentication dynamicforward
+		enableescapecommandline enablesshkeysign escapechar exitonforwardfailure
+		fingerprinthash forkafterauthentication forwardagent forwardx11
+		forwardx11timeout forwardx11trusted gatewayports globalknownhostsfile
+		hashknownhosts host hostbasedacceptedalgorithms hostbasedauthentication
+		hostbasedkeytypes hostkeyalgorithms hostkeyalias hostname identityagent
+		identityfile identityfile2 identitiesonly ignoreunknown include ipqos
+		kbdinteractiveauthentication kbdinteractivedevices keepalive
+		knownhostscommand kexalgorithms localcommand localforward loglevel
+		logverbose match macs nohostauthenticationforlocalhost
+		numberofpasswordprompts obscurekeystroketiming passwordauthentication
+		permitlocalcommand permitremoteopen port preferredauthentications
+		proxycommand proxyjump proxyusefdpass pubkeyacceptedalgorithms
+		pubkeyacceptedkeytypes pubkeyauthentication refuseconnection rekeylimit
+		remotecommand remoteforward requesttty requiredrsasize revokedhostkeys
+		securitykeyprovider sendenv serveralivecountmax serveraliveinterval
+		sessiontype setenv skeyauthentication stdinnull streamlocalbindmask
+		streamlocalbindunlink stricthostkeychecking syslogfacility tag
+		tcpkeepalive tisauthentication tunnel tunneldevice updatehostkeys user
+		userknownhostsfile verifyhostkeydns versionaddendum visualhostkey
+		warnweakcrypto xauthlocation
+	`)
+	return registry
+}

--- a/pkg/sshconfig/migrate.go
+++ b/pkg/sshconfig/migrate.go
@@ -1,0 +1,139 @@
+package sshconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type legacyHost struct {
+	Name   string            `json:"Name,omitempty" yaml:"Name,omitempty"`
+	Notes  string            `json:"Notes,omitempty" yaml:"Notes,omitempty"`
+	Data   map[string]string `json:"Data,omitempty" yaml:"-"`
+	Config map[string]string `json:"-" yaml:"config,omitempty"`
+}
+
+type legacyGroup struct {
+	Prefix string                `yaml:"Prefix,omitempty"`
+	Common map[string]string     `yaml:"Common,omitempty"`
+	Hosts  map[string]legacyHost `yaml:"Hosts,omitempty"`
+}
+
+type legacyYAML struct {
+	Global  map[string]string      `yaml:"global,omitempty"`
+	Default map[string]string      `yaml:"default,omitempty"`
+	Groups  map[string]legacyGroup `yaml:",inline"`
+}
+
+// MigrateLegacyYAML converts the previous map-based YAML format into a v3
+// document. It cannot recover ordering or repeated values already absent from
+// the legacy input.
+func MigrateLegacyYAML(data []byte, path string) (Schema, error) {
+	var legacy legacyYAML
+	if err := yaml.UnmarshalStrict(data, &legacy); err != nil {
+		return Schema{}, fmt.Errorf("sshconfig: decode legacy YAML: %w", err)
+	}
+	var output bytes.Buffer
+	writeLegacyHost(&output, "*", "", legacy.Global)
+	groupNames := sortedMapKeys(legacy.Groups)
+	for _, groupName := range groupNames {
+		group := legacy.Groups[groupName]
+		hostNames := sortedMapKeys(group.Hosts)
+		for _, hostName := range hostNames {
+			host := group.Hosts[hostName]
+			config := cloneStringMap(host.Config)
+			if config == nil {
+				config = make(map[string]string)
+			}
+			mergeMissing(config, group.Common)
+			mergeMissing(config, legacy.Default)
+			writeLegacyHost(&output, group.Prefix+hostName, host.Notes, config)
+		}
+	}
+	return schemaFromLegacyBytes(output.Bytes(), path)
+}
+
+// MigrateLegacyJSON converts the previous host-array JSON format into v3.
+func MigrateLegacyJSON(data []byte, path string) (Schema, error) {
+	var hosts []legacyHost
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&hosts); err != nil {
+		return Schema{}, fmt.Errorf("sshconfig: decode legacy JSON: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return Schema{}, err
+	}
+	var output bytes.Buffer
+	for _, host := range hosts {
+		writeLegacyHost(&output, host.Name, host.Notes, host.Data)
+	}
+	return schemaFromLegacyBytes(output.Bytes(), path)
+}
+
+func schemaFromLegacyBytes(data []byte, path string) (Schema, error) {
+	doc, err := Parse(data)
+	if err != nil {
+		return Schema{}, err
+	}
+	schemaDocument, err := doc.ToSchema(path)
+	if err != nil {
+		return Schema{}, err
+	}
+	return NewSchema(schemaDocument), nil
+}
+
+func writeLegacyHost(output *bytes.Buffer, name, notes string, config map[string]string) {
+	if name == "" || len(config) == 0 {
+		return
+	}
+	for _, note := range strings.Split(notes, "\n") {
+		if note != "" {
+			output.WriteString("# ")
+			output.WriteString(note)
+			output.WriteByte('\n')
+		}
+	}
+	output.WriteString("Host ")
+	output.WriteString(quoteArgument(name))
+	output.WriteByte('\n')
+	for _, key := range sortedMapKeys(config) {
+		output.WriteString("    ")
+		output.WriteString(key)
+		output.WriteByte(' ')
+		output.WriteString(quoteArgument(config[key]))
+		output.WriteByte('\n')
+	}
+}
+
+func sortedMapKeys[V any](values map[string]V) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func cloneStringMap(input map[string]string) map[string]string {
+	if input == nil {
+		return nil
+	}
+	result := make(map[string]string, len(input))
+	for key, value := range input {
+		result[key] = value
+	}
+	return result
+}
+
+func mergeMissing(destination, source map[string]string) {
+	for key, value := range source {
+		if _, exists := destination[key]; !exists {
+			destination[key] = value
+		}
+	}
+}

--- a/pkg/sshconfig/openssh_integration_test.go
+++ b/pkg/sshconfig/openssh_integration_test.go
@@ -1,0 +1,136 @@
+package sshconfig
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestOpenSSHRoundTripEffectiveConfiguration(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("OpenSSH integration fixture uses POSIX file permissions")
+	}
+	ssh, err := exec.LookPath("ssh")
+	if err != nil {
+		t.Skip("OpenSSH client is not installed")
+	}
+	t.Parallel()
+
+	directory := t.TempDir()
+	included := filepath.Join(directory, "included.conf")
+	writeTestConfig(t, included, "Host included\n    HostName included.example\n")
+	original := filepath.Join(directory, "original.conf")
+	generated := filepath.Join(directory, "generated.conf")
+	content := []byte("# preserve this comment\n" +
+		"Include " + included + "\n" +
+		"Host production\n" +
+		"    HostName=production.example\n" +
+		"    User deploy # inline comment\n" +
+		"    IdentityFile ~/.ssh/work\n" +
+		"    IdentityFile ~/.ssh/backup\n" +
+		"    SetEnv FOO=bar\n" +
+		"Host *\n" +
+		"    User fallback\n" +
+		"    ServerAliveInterval 30\n" +
+		"Match host=internal\n" +
+		"    HostName internal.example\n")
+	writeTestConfig(t, original, string(content))
+
+	doc, err := Parse(content)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	output, err := doc.MarshalPreserve()
+	if err != nil {
+		t.Fatalf("MarshalPreserve() error = %v", err)
+	}
+	writeTestConfig(t, generated, string(output))
+
+	for _, host := range []string{"production", "internal", "included", "other"} {
+		host := host
+		t.Run(host, func(t *testing.T) {
+			originalOutput := runSSHConfig(t, ssh, directory, original, host)
+			generatedOutput := runSSHConfig(t, ssh, directory, generated, host)
+			if !bytes.Equal(originalOutput, generatedOutput) {
+				t.Fatalf("effective configuration changed for %s\n--- original ---\n%s\n--- generated ---\n%s", host, originalOutput, generatedOutput)
+			}
+		})
+	}
+}
+
+func TestOpenSSHAcceptsSupportedLexicalForms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("OpenSSH integration fixture uses POSIX file permissions")
+	}
+	ssh, err := exec.LookPath("ssh")
+	if err != nil {
+		t.Skip("OpenSSH client is not installed")
+	}
+	t.Parallel()
+
+	directory := t.TempDir()
+	path := filepath.Join(directory, "config")
+	input := []byte("Host=example alias\n" +
+		"    HostName = example.test\n" +
+		"    ProxyCommand \"ssh -W %h:%p jump\" # comment\n" +
+		"    SetEnv FOO=bar BAZ=qux\n")
+	doc, err := Parse(input)
+	if err != nil || len(doc.Diagnostics()) != 0 {
+		t.Fatalf("Parse() = %v, diagnostics = %#v", err, doc.Diagnostics())
+	}
+	output, _ := doc.MarshalPreserve()
+	writeTestConfig(t, path, string(output))
+	got := runSSHConfig(t, ssh, directory, path, "example")
+	if !bytes.Contains(got, []byte("hostname example.test\n")) {
+		t.Fatalf("ssh -G output does not contain parsed hostname:\n%s", got)
+	}
+}
+
+func runSSHConfig(t *testing.T, ssh, home, config, host string) []byte {
+	t.Helper()
+	command := exec.Command(ssh, "-G", "-F", config, host)
+	command.Env = append(os.Environ(), "HOME="+home)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		t.Fatalf("ssh -G failed: %v: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes()
+}
+
+func FuzzEditMarshalReparse(f *testing.F) {
+	f.Add([]byte("Host example\n    User root\n"), "IdentityFile", "~/.ssh/work")
+	f.Add([]byte("# comment without newline"), "SetEnv", "FOO=bar")
+	f.Fuzz(func(t *testing.T, input []byte, keyword, value string) {
+		if keyword == "" || strings.ContainsAny(keyword, " \t\r\n=\"'") {
+			t.Skip()
+		}
+		doc, err := Parse(input)
+		if err != nil {
+			t.Fatalf("Parse() error = %v", err)
+		}
+		if _, err := doc.AppendDirective(keyword, value); err != nil {
+			t.Fatalf("AppendDirective() error = %v", err)
+		}
+		first, err := doc.MarshalPreserve()
+		if err != nil {
+			t.Fatalf("MarshalPreserve() error = %v", err)
+		}
+		reparsed, err := Parse(first)
+		if err != nil {
+			t.Fatalf("reparse error = %v", err)
+		}
+		second, err := reparsed.MarshalPreserve()
+		if err != nil {
+			t.Fatalf("second MarshalPreserve() error = %v", err)
+		}
+		if !bytes.Equal(first, second) {
+			t.Fatalf("serialization is unstable\nfirst: %q\nsecond: %q", first, second)
+		}
+	})
+}

--- a/pkg/sshconfig/parser.go
+++ b/pkg/sshconfig/parser.go
@@ -5,7 +5,11 @@ import "fmt"
 // Parse constructs a lossless syntax document. Unknown or malformed lines are
 // retained. Malformed quoting is reported through Document.Diagnostics.
 func Parse(input []byte) (*Document, error) {
-	doc := &Document{source: append([]byte(nil), input...)}
+	doc := &Document{
+		source:      append([]byte(nil), input...),
+		replacement: make(map[NodeID][]byte),
+		removed:     make(map[NodeID]bool),
+	}
 	line, offset := 1, 0
 	for offset < len(doc.source) {
 		contentEnd, lineEnd := scanLine(doc.source, offset)
@@ -17,6 +21,7 @@ func Parse(input []byte) (*Document, error) {
 		offset = lineEnd
 		line++
 	}
+	doc.nextID = NodeID(len(doc.nodes))
 	return doc, nil
 }
 
@@ -78,6 +83,7 @@ func parseLine(doc *Document, id NodeID, line, start, contentEnd, lineEnd int) N
 	directive.Arguments, directive.Comment, malformed = parseArguments(doc, line, start, i, contentEnd)
 	node.Kind = NodeDirective
 	node.Directive = directive
+	node.original = directive
 	if malformed {
 		node.Kind = NodeInvalid
 	}

--- a/pkg/sshconfig/schema.go
+++ b/pkg/sshconfig/schema.go
@@ -1,0 +1,298 @@
+package sshconfig
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v2"
+)
+
+// SchemaVersion is the lossless structured configuration format version.
+const SchemaVersion = 3
+
+// Schema is the root of the v3 YAML/JSON representation.
+type Schema struct {
+	SchemaVersion int              `json:"schemaVersion" yaml:"schemaVersion"`
+	Documents     []SchemaDocument `json:"documents" yaml:"documents"`
+}
+
+// SchemaDocument is one physical SSH configuration file.
+type SchemaDocument struct {
+	Path  string       `json:"path,omitempty" yaml:"path,omitempty"`
+	Nodes []SchemaNode `json:"nodes" yaml:"nodes"`
+}
+
+// SchemaNode preserves one physical source line. RawBase64 is authoritative
+// while its parsed Directive remains unchanged. If Directive is edited, the
+// importer renders only that node canonically.
+type SchemaNode struct {
+	Type      string           `json:"type" yaml:"type"`
+	RawBase64 string           `json:"rawBase64,omitempty" yaml:"rawBase64,omitempty"`
+	Directive *SchemaDirective `json:"directive,omitempty" yaml:"directive,omitempty"`
+}
+
+// SchemaDirective is an editable semantic view of a directive node.
+type SchemaDirective struct {
+	Keyword   string   `json:"keyword" yaml:"keyword"`
+	Arguments []string `json:"arguments,omitempty" yaml:"arguments,omitempty"`
+	Comment   string   `json:"comment,omitempty" yaml:"comment,omitempty"`
+}
+
+// ToSchema exports a document without discarding its original source bytes.
+func (d *Document) ToSchema(path string) (SchemaDocument, error) {
+	serialized, err := d.MarshalPreserve()
+	if err != nil {
+		return SchemaDocument{}, err
+	}
+	clean, err := Parse(serialized)
+	if err != nil {
+		return SchemaDocument{}, err
+	}
+	result := SchemaDocument{Path: path, Nodes: make([]SchemaNode, 0, len(clean.nodes))}
+	for _, node := range clean.nodes {
+		raw := clean.source[node.Span.Start:node.Span.End]
+		schemaNode := SchemaNode{
+			Type:      schemaNodeType(node.Kind),
+			RawBase64: base64.StdEncoding.EncodeToString(raw),
+		}
+		if node.Directive != nil && utf8.Valid(raw) {
+			directive := node.Directive
+			arguments := make([]string, 0, len(directive.Arguments))
+			for _, argument := range directive.Arguments {
+				arguments = append(arguments, argument.Value)
+			}
+			view := &SchemaDirective{
+				Keyword:   string(clean.source[directive.Keyword.Span.Start:directive.Keyword.Span.End]),
+				Arguments: arguments,
+			}
+			if directive.Comment != nil {
+				view.Comment = string(clean.source[directive.Comment.Span.Start:directive.Comment.Span.End])
+			}
+			schemaNode.Directive = view
+		}
+		result.Nodes = append(result.Nodes, schemaNode)
+	}
+	return result, nil
+}
+
+// NewSchema creates a v3 schema from one or more documents.
+func NewSchema(documents ...SchemaDocument) Schema {
+	return Schema{SchemaVersion: SchemaVersion, Documents: documents}
+}
+
+// Document reconstructs one schema document. An empty path selects the first
+// document when the schema contains exactly one document.
+func (s Schema) Document(path string) (*Document, error) {
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+	for _, document := range s.Documents {
+		if document.Path == path || path == "" && len(s.Documents) == 1 {
+			return document.Document()
+		}
+	}
+	return nil, fmt.Errorf("sshconfig: schema document %q not found", path)
+}
+
+// Document reconstructs a lossless syntax document from a v3 document.
+func (s SchemaDocument) Document() (*Document, error) {
+	var output bytes.Buffer
+	for index, node := range s.Nodes {
+		raw, err := decodeSchemaRaw(node.RawBase64)
+		if err != nil {
+			return nil, fmt.Errorf("sshconfig: schema node %d: %w", index, err)
+		}
+		if node.Directive == nil {
+			if len(raw) == 0 && node.Type != "blank" {
+				return nil, fmt.Errorf("sshconfig: schema node %d has neither raw bytes nor a directive", index)
+			}
+			output.Write(raw)
+			continue
+		}
+		if schemaRawMatchesDirective(raw, node.Directive) {
+			output.Write(raw)
+			continue
+		}
+		output.Write(renderSchemaDirective(node.Directive, detectLineEnding(raw)))
+	}
+	return Parse(output.Bytes())
+}
+
+// Validate checks the v3 envelope and node shapes.
+func (s Schema) Validate() error {
+	if s.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("sshconfig: unsupported schema version %d", s.SchemaVersion)
+	}
+	if len(s.Documents) == 0 {
+		return fmt.Errorf("sshconfig: schema has no documents")
+	}
+	seen := make(map[string]bool)
+	for index, document := range s.Documents {
+		if document.Path != "" {
+			if seen[document.Path] {
+				return fmt.Errorf("sshconfig: duplicate schema document path %q", document.Path)
+			}
+			seen[document.Path] = true
+		}
+		for nodeIndex, node := range document.Nodes {
+			switch node.Type {
+			case "blank", "comment", "directive", "invalid":
+			default:
+				return fmt.Errorf("sshconfig: document %d node %d has unknown type %q", index, nodeIndex, node.Type)
+			}
+			if node.Directive != nil && node.Directive.Keyword == "" {
+				return fmt.Errorf("sshconfig: document %d node %d has an empty keyword", index, nodeIndex)
+			}
+			if node.Type == "directive" && node.Directive == nil && node.RawBase64 == "" {
+				return fmt.Errorf("sshconfig: document %d node %d has no directive or raw bytes", index, nodeIndex)
+			}
+			if node.Type != "directive" && node.Directive != nil {
+				return fmt.Errorf("sshconfig: document %d node %d of type %q has a directive", index, nodeIndex, node.Type)
+			}
+			if _, err := decodeSchemaRaw(node.RawBase64); err != nil {
+				return fmt.Errorf("sshconfig: document %d node %d: %w", index, nodeIndex, err)
+			}
+		}
+	}
+	return nil
+}
+
+// MarshalSchemaJSON serializes a validated schema as indented JSON.
+func MarshalSchemaJSON(schema Schema) ([]byte, error) {
+	if err := schema.Validate(); err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(schema, "", "  ")
+}
+
+// UnmarshalSchemaJSON strictly decodes one JSON schema document.
+func UnmarshalSchemaJSON(data []byte) (Schema, error) {
+	var schema Schema
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&schema); err != nil {
+		return Schema{}, fmt.Errorf("sshconfig: decode v3 JSON: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return Schema{}, err
+	}
+	if err := schema.Validate(); err != nil {
+		return Schema{}, err
+	}
+	return schema, nil
+}
+
+// MarshalSchemaYAML serializes a validated schema as YAML.
+func MarshalSchemaYAML(schema Schema) ([]byte, error) {
+	if err := schema.Validate(); err != nil {
+		return nil, err
+	}
+	return yaml.Marshal(schema)
+}
+
+// UnmarshalSchemaYAML strictly decodes one YAML schema document.
+func UnmarshalSchemaYAML(data []byte) (Schema, error) {
+	var schema Schema
+	if err := yaml.UnmarshalStrict(data, &schema); err != nil {
+		return Schema{}, fmt.Errorf("sshconfig: decode v3 YAML: %w", err)
+	}
+	if err := schema.Validate(); err != nil {
+		return Schema{}, err
+	}
+	return schema, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err == io.EOF {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("sshconfig: decode trailing JSON: %w", err)
+	}
+	return fmt.Errorf("sshconfig: multiple JSON values are not allowed")
+}
+
+func schemaNodeType(kind NodeKind) string {
+	switch kind {
+	case NodeBlank:
+		return "blank"
+	case NodeComment:
+		return "comment"
+	case NodeDirective:
+		return "directive"
+	default:
+		return "invalid"
+	}
+}
+
+func decodeSchemaRaw(encoded string) ([]byte, error) {
+	if encoded == "" {
+		return nil, nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("invalid rawBase64: %w", err)
+	}
+	return decoded, nil
+}
+
+func schemaRawMatchesDirective(raw []byte, expected *SchemaDirective) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	doc, err := Parse(raw)
+	if err != nil || len(doc.nodes) != 1 || doc.nodes[0].Directive == nil {
+		return false
+	}
+	directive := doc.nodes[0].Directive
+	actual := &SchemaDirective{
+		Keyword: string(doc.source[directive.Keyword.Span.Start:directive.Keyword.Span.End]),
+	}
+	for _, argument := range directive.Arguments {
+		actual.Arguments = append(actual.Arguments, argument.Value)
+	}
+	if directive.Comment != nil {
+		actual.Comment = string(doc.source[directive.Comment.Span.Start:directive.Comment.Span.End])
+	}
+	return reflect.DeepEqual(actual, expected)
+}
+
+func renderSchemaDirective(directive *SchemaDirective, lineEnding string) []byte {
+	if lineEnding == "" {
+		lineEnding = "\n"
+	}
+	var output bytes.Buffer
+	output.WriteString(directive.Keyword)
+	if len(directive.Arguments) > 0 {
+		output.WriteByte(' ')
+		writeArguments(&output, directive.Arguments)
+	}
+	if directive.Comment != "" {
+		output.WriteByte(' ')
+		if directive.Comment[0] != '#' {
+			output.WriteByte('#')
+			output.WriteByte(' ')
+		}
+		output.WriteString(directive.Comment)
+	}
+	output.WriteString(lineEnding)
+	return output.Bytes()
+}
+
+func detectLineEnding(raw []byte) string {
+	if bytes.HasSuffix(raw, []byte("\r\n")) {
+		return "\r\n"
+	}
+	if bytes.HasSuffix(raw, []byte("\n")) {
+		return "\n"
+	}
+	if bytes.HasSuffix(raw, []byte("\r")) {
+		return "\r"
+	}
+	return ""
+}

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -1,0 +1,158 @@
+package sshconfig
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestSchemaJSONAndYAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+	input := []byte("# note\r\nHost=example\r\n\tIdentityFile first\r\n\tIdentityFile second # backup\r\n")
+	doc, _ := Parse(input)
+	schemaDocument, err := doc.ToSchema("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := NewSchema(schemaDocument)
+
+	jsonData, err := MarshalSchemaJSON(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromJSON, err := UnmarshalSchemaJSON(jsonData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSchemaDocumentBytes(t, fromJSON, "config", input)
+
+	yamlData, err := MarshalSchemaYAML(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromYAML, err := UnmarshalSchemaYAML(yamlData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSchemaDocumentBytes(t, fromYAML, "config", input)
+}
+
+func TestSchemaPreservesNonUTF8RawBytes(t *testing.T) {
+	t.Parallel()
+	input := []byte{'#', ' ', 0xff, '\n'}
+	doc, _ := Parse(input)
+	schemaDocument, err := doc.ToSchema("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := NewSchema(schemaDocument)
+	data, err := MarshalSchemaJSON(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := UnmarshalSchemaJSON(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSchemaDocumentBytes(t, decoded, "config", input)
+}
+
+func TestSchemaRendersOnlyChangedDirective(t *testing.T) {
+	t.Parallel()
+	input := []byte("# untouched\r\n\tUser = old # account\r\nHost example\r\n")
+	doc, _ := Parse(input)
+	schemaDocument, _ := doc.ToSchema("config")
+	schemaDocument.Nodes[1].Directive.Arguments = []string{"new user"}
+	reconstructed, err := schemaDocument.Document()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := reconstructed.MarshalPreserve()
+	want := []byte("# untouched\r\nUser \"new user\" # account\r\nHost example\r\n")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestSchemaStrictValidation(t *testing.T) {
+	t.Parallel()
+	if _, err := UnmarshalSchemaJSON([]byte(`{"schemaVersion":3,"documents":[],"extra":true}`)); err == nil {
+		t.Fatal("JSON accepted an unknown field")
+	}
+	if _, err := UnmarshalSchemaYAML([]byte("schemaVersion: 3\ndocuments: []\nextra: true\n")); err == nil {
+		t.Fatal("YAML accepted an unknown field")
+	}
+	badVersion := Schema{SchemaVersion: 2, Documents: []SchemaDocument{{}}}
+	if err := badVersion.Validate(); err == nil {
+		t.Fatal("schema accepted an old version")
+	}
+	badBase64 := NewSchema(SchemaDocument{Nodes: []SchemaNode{{Type: "comment", RawBase64: "!"}}})
+	if err := badBase64.Validate(); err == nil {
+		t.Fatal("schema accepted invalid base64")
+	}
+	wrongNodeShape := NewSchema(SchemaDocument{Nodes: []SchemaNode{{
+		Type:      "comment",
+		Directive: &SchemaDirective{Keyword: "Host"},
+	}}})
+	if err := wrongNodeShape.Validate(); err == nil {
+		t.Fatal("schema accepted a directive view on a comment node")
+	}
+}
+
+func TestMigrateLegacyFormats(t *testing.T) {
+	t.Parallel()
+	legacyYAML := []byte(`global:
+  ServerAliveInterval: "30"
+Group production:
+  Prefix: corp-
+  Common:
+    User: deploy
+  Hosts:
+    api:
+      Notes: main API
+      config:
+        HostName: api.example
+`)
+	schema, err := MigrateLegacyYAML(legacyYAML, "config")
+	if err != nil {
+		t.Fatalf("MigrateLegacyYAML() error = %v", err)
+	}
+	doc, err := schema.Document("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	yamlOutput, _ := doc.MarshalPreserve()
+	for _, expected := range []string{"Host *", "ServerAliveInterval 30", "Host corp-api", "User deploy", "HostName api.example"} {
+		if !strings.Contains(string(yamlOutput), expected) {
+			t.Errorf("migrated YAML output missing %q:\n%s", expected, yamlOutput)
+		}
+	}
+
+	legacyJSON := []byte(`[{"Name":"example","Notes":"note","Data":{"User":"root","IdentityFile":"~/.ssh/id"}}]`)
+	schema, err = MigrateLegacyJSON(legacyJSON, "config")
+	if err != nil {
+		t.Fatalf("MigrateLegacyJSON() error = %v", err)
+	}
+	doc, _ = schema.Document("config")
+	jsonOutput, _ := doc.MarshalPreserve()
+	for _, expected := range []string{"# note", "Host example", "IdentityFile ~/.ssh/id", "User root"} {
+		if !strings.Contains(string(jsonOutput), expected) {
+			t.Errorf("migrated JSON output missing %q:\n%s", expected, jsonOutput)
+		}
+	}
+}
+
+func assertSchemaDocumentBytes(t *testing.T, schema Schema, path string, want []byte) {
+	t.Helper()
+	doc, err := schema.Document(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := doc.MarshalPreserve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("schema round trip mismatch\n got: %q\nwant: %q", got, want)
+	}
+}

--- a/pkg/sshconfig/validate.go
+++ b/pkg/sshconfig/validate.go
@@ -1,0 +1,133 @@
+package sshconfig
+
+import "fmt"
+
+// Severity is the importance of a validation issue.
+type Severity uint8
+
+const (
+	SeverityInfo Severity = iota
+	SeverityWarning
+	SeverityError
+)
+
+// UnknownDirectivePolicy controls diagnostics for directives absent from the
+// OpenSSH keyword registry.
+type UnknownDirectivePolicy uint8
+
+const (
+	UnknownDirectiveIgnore UnknownDirectivePolicy = iota
+	UnknownDirectiveWarn
+	UnknownDirectiveError
+)
+
+// ValidateOptions controls syntax and keyword validation.
+type ValidateOptions struct {
+	UnknownDirective UnknownDirectivePolicy
+}
+
+// ValidationIssue is a structured, source-positioned diagnostic.
+type ValidationIssue struct {
+	NodeID   NodeID
+	Position Position
+	Severity Severity
+	Code     string
+	Message  string
+}
+
+// Validate checks syntax and OpenSSH keyword compatibility without changing
+// or evaluating the document.
+func (d *Document) Validate(options ValidateOptions) []ValidationIssue {
+	if d == nil {
+		return []ValidationIssue{{
+			Severity: SeverityError,
+			Code:     "nil-document",
+			Message:  "document is nil",
+		}}
+	}
+	issues := make([]ValidationIssue, 0, len(d.diagnostics))
+	for _, diagnostic := range d.diagnostics {
+		issues = append(issues, ValidationIssue{
+			NodeID:   d.nodeIDAtOffset(diagnostic.Position.Offset),
+			Position: diagnostic.Position,
+			Severity: SeverityError,
+			Code:     "invalid-syntax",
+			Message:  diagnostic.Message,
+		})
+	}
+	for _, node := range d.nodes {
+		if d.removed[node.ID] || node.Directive == nil {
+			continue
+		}
+		directive := node.Directive
+		position := directive.Keyword.Position
+		if position.Line == 0 {
+			position = Position{Line: 1, Column: 1}
+		}
+		if len(directive.Arguments) == 0 {
+			issues = append(issues, ValidationIssue{
+				NodeID:   node.ID,
+				Position: position,
+				Severity: SeverityError,
+				Code:     "missing-argument",
+				Message:  fmt.Sprintf("directive %q requires an argument", directive.KeywordValue),
+			})
+		}
+
+		info, ok := LookupKeyword(directive.KeywordValue)
+		if !ok {
+			severity, report := unknownSeverity(options.UnknownDirective)
+			if report {
+				issues = append(issues, ValidationIssue{
+					NodeID:   node.ID,
+					Position: position,
+					Severity: severity,
+					Code:     "unknown-directive",
+					Message:  fmt.Sprintf("unknown OpenSSH directive %q", directive.KeywordValue),
+				})
+			}
+			continue
+		}
+		switch info.Status {
+		case KeywordIgnored:
+			issues = append(issues, keywordIssue(node.ID, position, SeverityInfo, "ignored-directive", info.Name, "is ignored by OpenSSH"))
+		case KeywordDeprecated:
+			issues = append(issues, keywordIssue(node.ID, position, SeverityWarning, "deprecated-directive", info.Name, "is deprecated by OpenSSH"))
+		case KeywordUnsupported:
+			issues = append(issues, keywordIssue(node.ID, position, SeverityWarning, "unsupported-directive", info.Name, "is unsupported by OpenSSH"))
+		case KeywordPlatformDependent:
+			issues = append(issues, keywordIssue(node.ID, position, SeverityInfo, "platform-dependent-directive", info.Name, "depends on OpenSSH build features"))
+		}
+	}
+	return issues
+}
+
+func unknownSeverity(policy UnknownDirectivePolicy) (Severity, bool) {
+	switch policy {
+	case UnknownDirectiveWarn:
+		return SeverityWarning, true
+	case UnknownDirectiveError:
+		return SeverityError, true
+	default:
+		return SeverityInfo, false
+	}
+}
+
+func keywordIssue(id NodeID, position Position, severity Severity, code, name, suffix string) ValidationIssue {
+	return ValidationIssue{
+		NodeID:   id,
+		Position: position,
+		Severity: severity,
+		Code:     code,
+		Message:  fmt.Sprintf("directive %q %s", name, suffix),
+	}
+}
+
+func (d *Document) nodeIDAtOffset(offset int) NodeID {
+	for _, node := range d.nodes {
+		if offset >= node.Span.Start && offset < node.Span.End {
+			return node.ID
+		}
+	}
+	return 0
+}

--- a/pkg/sshconfig/validate_test.go
+++ b/pkg/sshconfig/validate_test.go
@@ -1,0 +1,87 @@
+package sshconfig
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestLookupKeyword(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status KeywordStatus
+	}{
+		{"ProxyJump", KeywordSupported},
+		{"MATCH", KeywordSupported},
+		{"Protocol", KeywordIgnored},
+		{"Cipher", KeywordDeprecated},
+		{"KerberosAuthentication", KeywordUnsupported},
+		{"PKCS11Provider", KeywordPlatformDependent},
+	}
+	for _, test := range tests {
+		info, ok := LookupKeyword(test.name)
+		if !ok || info.Status != test.status {
+			t.Errorf("LookupKeyword(%q) = %#v, %v", test.name, info, ok)
+		}
+	}
+	if _, ok := LookupKeyword("FutureOption"); ok {
+		t.Fatal("future option unexpectedly registered")
+	}
+}
+
+func TestValidateReportsWithoutChangingSource(t *testing.T) {
+	t.Parallel()
+	input := []byte("Host example\nFutureOption value\nCipher old\nProtocol 2\nKerberosAuthentication yes\n")
+	doc, _ := Parse(input)
+	issues := doc.Validate(ValidateOptions{UnknownDirective: UnknownDirectiveError})
+	wantCodes := map[string]bool{
+		"unknown-directive":     false,
+		"deprecated-directive":  false,
+		"ignored-directive":     false,
+		"unsupported-directive": false,
+	}
+	for _, issue := range issues {
+		if _, ok := wantCodes[issue.Code]; ok {
+			wantCodes[issue.Code] = true
+		}
+	}
+	for code, found := range wantCodes {
+		if !found {
+			t.Errorf("missing issue %q: %#v", code, issues)
+		}
+	}
+	got, err := doc.MarshalPreserve()
+	if err != nil || !bytes.Equal(got, input) {
+		t.Fatalf("validation changed source: %q, %v", got, err)
+	}
+}
+
+func TestValidateSyntaxAndArguments(t *testing.T) {
+	t.Parallel()
+	doc, _ := Parse([]byte("Host\nUser \"unfinished\n"))
+	issues := doc.Validate(ValidateOptions{})
+	var syntax, missing bool
+	for _, issue := range issues {
+		syntax = syntax || issue.Code == "invalid-syntax"
+		missing = missing || issue.Code == "missing-argument"
+	}
+	if !syntax || !missing {
+		t.Fatalf("issues = %#v", issues)
+	}
+}
+
+func TestUnknownDirectivePolicies(t *testing.T) {
+	t.Parallel()
+	doc, _ := Parse([]byte("FutureOption value\n"))
+	if got := doc.Validate(ValidateOptions{UnknownDirective: UnknownDirectiveIgnore}); len(got) != 0 {
+		t.Fatalf("ignore issues = %#v", got)
+	}
+	warn := doc.Validate(ValidateOptions{UnknownDirective: UnknownDirectiveWarn})
+	if len(warn) != 1 || warn[0].Severity != SeverityWarning {
+		t.Fatalf("warn issues = %#v", warn)
+	}
+	fail := doc.Validate(ValidateOptions{UnknownDirective: UnknownDirectiveError})
+	if len(fail) != 1 || fail[0].Severity != SeverityError {
+		t.Fatalf("error issues = %#v", fail)
+	}
+}

--- a/pkg/sshconfig/writer.go
+++ b/pkg/sshconfig/writer.go
@@ -1,0 +1,107 @@
+package sshconfig
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// MarshalPreserve serializes the document while copying unchanged nodes
+// directly from the original source.
+func (d *Document) MarshalPreserve() ([]byte, error) {
+	if d == nil {
+		return nil, fmt.Errorf("sshconfig: nil document")
+	}
+	var out bytes.Buffer
+	for _, node := range d.nodes {
+		if d.removed[node.ID] {
+			continue
+		}
+		if replacement, ok := d.replacement[node.ID]; ok {
+			out.Write(replacement)
+			continue
+		}
+		if node.Span.Start < 0 || node.Span.End < node.Span.Start || node.Span.End > len(d.source) {
+			return nil, fmt.Errorf("sshconfig: invalid span for node %d", node.ID)
+		}
+		out.Write(d.source[node.Span.Start:node.Span.End])
+	}
+	return out.Bytes(), nil
+}
+
+// SaveOptions controls atomic file replacement.
+type SaveOptions struct {
+	// Mode is used for a new file. Zero defaults to 0600.
+	Mode fs.FileMode
+	// PreserveMode retains an existing regular file's permission bits.
+	PreserveMode bool
+}
+
+// Save atomically writes a document to path. Symbolic-link destinations are
+// rejected so a caller cannot unintentionally replace a link target.
+func (d *Document) Save(path string, options SaveOptions) error {
+	data, err := d.MarshalPreserve()
+	if err != nil {
+		return err
+	}
+	return SaveAtomic(path, data, options)
+}
+
+// SaveAtomic writes data to a temporary file in the destination directory,
+// syncs it, and atomically renames it over path.
+func SaveAtomic(path string, data []byte, options SaveOptions) error {
+	if path == "" {
+		return fmt.Errorf("sshconfig: destination path is empty")
+	}
+	mode := options.Mode.Perm()
+	if mode == 0 {
+		mode = 0600
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("sshconfig: refusing symbolic-link destination %s", path)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("sshconfig: destination %s is not a regular file", path)
+		}
+		if options.PreserveMode {
+			mode = info.Mode().Perm()
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("sshconfig: inspect destination %s: %w", path, err)
+	}
+
+	directory := filepath.Dir(path)
+	temp, err := os.CreateTemp(directory, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("sshconfig: create temporary file: %w", err)
+	}
+	tempPath := temp.Name()
+	closed := false
+	defer func() {
+		if !closed {
+			_ = temp.Close()
+		}
+		_ = os.Remove(tempPath)
+	}()
+
+	if err := temp.Chmod(mode); err != nil {
+		return fmt.Errorf("sshconfig: set temporary file mode: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		return fmt.Errorf("sshconfig: write temporary file: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		return fmt.Errorf("sshconfig: sync temporary file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("sshconfig: close temporary file: %w", err)
+	}
+	closed = true
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("sshconfig: replace destination %s: %w", path, err)
+	}
+	return nil
+}

--- a/pkg/sshconfig/writer_test.go
+++ b/pkg/sshconfig/writer_test.go
@@ -1,0 +1,133 @@
+package sshconfig
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMarshalPreserveWithoutEdits(t *testing.T) {
+	t.Parallel()
+	input := []byte("# comment\r\nHost=example\r\n\tUser root\r\n")
+	doc, _ := Parse(input)
+	got, err := doc.MarshalPreserve()
+	if err != nil {
+		t.Fatalf("MarshalPreserve() error = %v", err)
+	}
+	if !bytes.Equal(got, input) {
+		t.Fatalf("output = %q, want %q", got, input)
+	}
+}
+
+func TestReplaceDirectivePreservesSurroundings(t *testing.T) {
+	t.Parallel()
+	input := []byte("Host example\r\n\tUser = old # account\r\nIdentityFile first\r\nIdentityFile second\r\n")
+	doc, _ := Parse(input)
+	if err := doc.ReplaceDirective(1, "User", "new user"); err != nil {
+		t.Fatalf("ReplaceDirective() error = %v", err)
+	}
+	got, err := doc.MarshalPreserve()
+	if err != nil {
+		t.Fatalf("MarshalPreserve() error = %v", err)
+	}
+	want := []byte("Host example\r\n\tUser = \"new user\" # account\r\nIdentityFile first\r\nIdentityFile second\r\n")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestRemoveAndInsertDirective(t *testing.T) {
+	t.Parallel()
+	doc, _ := Parse([]byte("Host example\nIdentityFile first"))
+	if err := doc.RemoveNode(1); err != nil {
+		t.Fatalf("RemoveNode() error = %v", err)
+	}
+	id, err := doc.InsertDirectiveAfter(0, "IdentityFile", "second")
+	if err != nil {
+		t.Fatalf("InsertDirectiveAfter() error = %v", err)
+	}
+	if id < 2 {
+		t.Fatalf("inserted id = %d", id)
+	}
+	if _, err := doc.AppendDirective("SetEnv", "FOO=bar", "HASH=#value"); err != nil {
+		t.Fatalf("AppendDirective() error = %v", err)
+	}
+	got, _ := doc.MarshalPreserve()
+	want := "Host example\nIdentityFile second\nSetEnv FOO=bar \"HASH=#value\"\n"
+	if string(got) != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestEditErrors(t *testing.T) {
+	t.Parallel()
+	doc, _ := Parse([]byte("# comment\n"))
+	if err := doc.ReplaceDirective(0, "User", "root"); err == nil {
+		t.Fatal("replaced a comment node")
+	}
+	if err := doc.RemoveNode(99); err == nil {
+		t.Fatal("removed an unknown node")
+	}
+	if _, err := doc.InsertDirectiveAfter(99, "User", "root"); err == nil {
+		t.Fatal("inserted after an unknown node")
+	}
+	if _, err := doc.AppendDirective(""); err == nil {
+		t.Fatal("appended an empty keyword")
+	}
+}
+
+func TestSaveAtomic(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	path := filepath.Join(directory, "config")
+	if err := os.WriteFile(path, []byte("old"), 0640); err != nil {
+		t.Fatal(err)
+	}
+	doc, _ := Parse([]byte("Host example\n"))
+	if err := doc.Save(path, SaveOptions{PreserveMode: true}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "Host example\n" {
+		t.Fatalf("saved content = %q", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotMode := info.Mode().Perm(); gotMode != 0640 {
+		t.Fatalf("saved mode = %o, want 640", gotMode)
+	}
+	matches, err := filepath.Glob(filepath.Join(directory, ".config.tmp-*"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("temporary files remain: %v, %v", matches, err)
+	}
+}
+
+func TestSaveAtomicRejectsSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symbolic links require additional privileges on Windows")
+	}
+	t.Parallel()
+	directory := t.TempDir()
+	target := filepath.Join(directory, "target")
+	link := filepath.Join(directory, "config")
+	if err := os.WriteFile(target, []byte("unchanged"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveAtomic(link, []byte("changed"), SaveOptions{}); err == nil {
+		t.Fatal("SaveAtomic() accepted a symbolic link")
+	}
+	got, err := os.ReadFile(target)
+	if err != nil || string(got) != "unchanged" {
+		t.Fatalf("target changed: %q, %v", got, err)
+	}
+}


### PR DESCRIPTION
## Summary

This is an integration-only PR for the already separated and merged stack #11–#17.

GitHub merged each stacked PR into its immediate feature-branch base. As a result, only #11 reached `main`; this PR forwards the six remaining commits (#12–#17) to `main` without adding code beyond that reviewed stack.

## Included work

- lossless editor and atomic writer (#12)
- OpenSSH keyword validation (#13)
- Include graph resolver (#14)
- OpenSSH compatibility tests (#15)
- v3 lossless YAML/JSON schema and legacy migration (#16)
- opt-in lossless CLI mode (#17)

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./pkg/sshconfig`
- `git diff --check`

Full `go vet ./...` retains the pre-existing malformed struct tag warning at `internal/parser/define.go:141`.