### PR TITLE
fix: fail closed on lossy legacy conversions

### DIFF
--- a/internal/fn/detect_strict_test.go
+++ b/internal/fn/detect_strict_test.go
@@ -1,0 +1,45 @@
+package fn_test
+
+import (
+	"strings"
+	"testing"
+
+	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
+)
+
+func TestDetectStringTypeStrictRejectsMalformedStructuredInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "json object", input: "{broken json}\n", want: "invalid JSON input"},
+		{name: "json array", input: "[{}", want: "invalid JSON input"},
+		{name: "legacy yaml", input: "global: [\n", want: "invalid YAML input"},
+		{name: "legacy group yaml", input: "Group work:\n  Hosts: [\n", want: "invalid YAML input"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Fn.DetectStringTypeStrict(test.input)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("DetectStringTypeStrict() error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDetectStringTypeStrictKeepsSSHText(t *testing.T) {
+	t.Parallel()
+
+	got, err := Fn.DetectStringTypeStrict("Host example\n  User alice\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "TEXT" {
+		t.Fatalf("DetectStringTypeStrict() = %q, want TEXT", got)
+	}
+}

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -75,12 +75,18 @@ func GetYamlBytes(data any) []byte {
 }
 
 func GetYamlData(input string) (yamlConfig Define.YAMLOutput) {
-	err := yaml.Unmarshal([]byte(input), &yamlConfig)
+	yamlConfig, err := GetYamlDataStrict(input)
 	if err != nil {
 		fmt.Println("Error unmarshalling YAML:", err)
-		return yamlConfig
 	}
 	return yamlConfig
+}
+
+// GetYamlDataStrict decodes the legacy YAML format without hiding syntax or
+// type errors from callers that must avoid destructive conversions.
+func GetYamlDataStrict(input string) (yamlConfig Define.YAMLOutput, err error) {
+	err = yaml.Unmarshal([]byte(input), &yamlConfig)
+	return yamlConfig, err
 }
 
 func GetJSONBytes(data any) []byte {
@@ -93,12 +99,17 @@ func GetJSONBytes(data any) []byte {
 }
 
 func GetJSONData(input string) (jsonConfig []Define.HostConfigForJSON) {
-	err := json.Unmarshal([]byte(input), &jsonConfig)
+	jsonConfig, err := GetJSONDataStrict(input)
 	if err != nil {
 		fmt.Println("Error unmarshalling JSON:", err)
-		return jsonConfig
 	}
 	return jsonConfig
+}
+
+// GetJSONDataStrict decodes the legacy JSON format without hiding errors.
+func GetJSONDataStrict(input string) (jsonConfig []Define.HostConfigForJSON, err error) {
+	err = json.Unmarshal([]byte(input), &jsonConfig)
+	return jsonConfig, err
 }
 
 func DetectStringType(input string) string {
@@ -118,6 +129,48 @@ func DetectStringType(input string) string {
 		return "YAML"
 	}
 	return "TEXT"
+}
+
+// DetectStringTypeStrict preserves the legacy auto-detection behavior for
+// valid input, but treats text that clearly starts as a structured document as
+// malformed structured input instead of falling back to SSH text.
+func DetectStringTypeStrict(input string) (string, error) {
+	trimmedInput := strings.TrimSpace(input)
+	if trimmedInput == "" {
+		return "TEXT", nil
+	}
+
+	if strings.HasPrefix(trimmedInput, "{") || strings.HasPrefix(trimmedInput, "[") {
+		var value []Define.HostConfigForJSON
+		if err := json.Unmarshal([]byte(trimmedInput), &value); err != nil {
+			return "", fmt.Errorf("invalid JSON input: %w", err)
+		}
+		return "JSON", nil
+	}
+
+	if looksLikeLegacyYAML(trimmedInput) {
+		var value Define.YAMLOutput
+		if err := yaml.Unmarshal([]byte(trimmedInput), &value); err != nil {
+			return "", fmt.Errorf("invalid YAML input: %w", err)
+		}
+		return "YAML", nil
+	}
+
+	return DetectStringType(input), nil
+}
+
+func looksLikeLegacyYAML(input string) bool {
+	for _, line := range strings.Split(input, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || line == "---" {
+			continue
+		}
+		lower := strings.ToLower(line)
+		return strings.HasPrefix(lower, "global:") ||
+			strings.HasPrefix(lower, "default:") ||
+			(strings.HasPrefix(lower, "group ") && strings.Contains(line, ":"))
+	}
+	return false
 }
 
 func GetPathContent(src string) ([]byte, error) {

--- a/internal/parser/json.go
+++ b/internal/parser/json.go
@@ -17,6 +17,8 @@
 package parser
 
 import (
+	"fmt"
+
 	Define "github.com/soulteary/ssh-config/v2/internal/define"
 	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
 )
@@ -39,7 +41,15 @@ func ConvertToJSON(input []Define.HostConfig) []byte {
 }
 
 func GroupJSONConfig(input string) []Define.HostConfig {
-	jsonConfig := Fn.GetJSONData(input)
+	hostConfigs, _ := GroupJSONConfigStrict(input)
+	return hostConfigs
+}
+
+func GroupJSONConfigStrict(input string) ([]Define.HostConfig, error) {
+	jsonConfig, err := Fn.GetJSONDataStrict(input)
+	if err != nil {
+		return nil, fmt.Errorf("decode legacy JSON: %w", err)
+	}
 
 	var hostConfigs []Define.HostConfig
 
@@ -55,5 +65,5 @@ func GroupJSONConfig(input string) []Define.HostConfig {
 		hostConfigs = append(hostConfigs, config)
 	}
 
-	return hostConfigs
+	return hostConfigs, nil
 }

--- a/internal/parser/legacy_safety_test.go
+++ b/internal/parser/legacy_safety_test.go
@@ -1,0 +1,62 @@
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	Parser "github.com/soulteary/ssh-config/v2/internal/parser"
+)
+
+func TestGroupStructuredConfigStrictReturnsDecodeErrors(t *testing.T) {
+	t.Parallel()
+
+	if _, err := Parser.GroupJSONConfigStrict("{broken json}"); err == nil {
+		t.Fatal("GroupJSONConfigStrict() unexpectedly accepted malformed JSON")
+	}
+	if _, err := Parser.GroupYAMLConfigStrict("global: ["); err == nil {
+		t.Fatal("GroupYAMLConfigStrict() unexpectedly accepted malformed YAML")
+	}
+}
+
+func TestGroupSSHConfigRejectsLossyLegacyInputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "global directive", input: "ServerAliveInterval 30\nHost example\n  User alice\n", want: "global directives"},
+		{name: "match", input: "Host first\n  User alice\nMatch host second\n  User bob\n", want: "match cannot be represented"},
+		{name: "include", input: "Include config.d/*\n", want: "include cannot be represented"},
+		{name: "unknown", input: "Host example\n  SendEnv FOO\n", want: "not supported"},
+		{name: "repeated", input: "Host example\n  IdentityFile ~/.ssh/a\n  IdentityFile ~/.ssh/b\n", want: "repeated directive"},
+		{name: "duplicate host", input: "Host example\n  User alice\nHost example\n  User bob\n", want: "duplicate Host block"},
+		{name: "malformed quote", input: "Host example\n  ProxyCommand \"unterminated\n", want: "unterminated quoted argument"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Parser.GroupSSHConfig(test.input)
+			if err == nil {
+				t.Fatal("GroupSSHConfig() unexpectedly succeeded")
+			}
+			if !strings.Contains(err.Error(), test.want) || !strings.Contains(err.Error(), "use -lossless") {
+				t.Fatalf("GroupSSHConfig() error = %q, want %q and lossless hint", err, test.want)
+			}
+		})
+	}
+}
+
+func TestGroupSSHConfigAcceptsRepresentableLegacyInput(t *testing.T) {
+	t.Parallel()
+
+	configs, err := Parser.GroupSSHConfig("Host example\n  HostName example.com\n  User alice\n  Port 2222\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(configs) != 1 || configs[0].Name != "example" || configs[0].Config["User"] != "alice" {
+		t.Fatalf("GroupSSHConfig() = %#v", configs)
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -33,9 +33,17 @@ func Process(fileType string, userInput string, args Cmd.Args) ([]byte, error) {
 
 	switch strings.ToUpper(fileType) {
 	case "YAML":
-		hostConfigs = GroupYAMLConfig(userInput)
+		var err error
+		hostConfigs, err = GroupYAMLConfigStrict(userInput)
+		if err != nil {
+			return nil, err
+		}
 	case "JSON":
-		hostConfigs = GroupJSONConfig(userInput)
+		var err error
+		hostConfigs, err = GroupJSONConfigStrict(userInput)
+		if err != nil {
+			return nil, err
+		}
 	case "TEXT":
 		var err error
 		hostConfigs, err = GroupSSHConfig(userInput)

--- a/internal/parser/ssh.go
+++ b/internal/parser/ssh.go
@@ -25,7 +25,17 @@ import (
 	Define "github.com/soulteary/ssh-config/v2/internal/define"
 	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
 	"github.com/soulteary/ssh-config/v2/pkg/lexer"
+	"github.com/soulteary/ssh-config/v2/pkg/sshconfig"
 )
+
+var legacySSHDirectives = map[string]struct{}{
+	"hostname": {}, "user": {}, "identityfile": {}, "port": {},
+	"controlpath": {}, "controlpersist": {}, "tcpkeepalive": {},
+	"compression": {}, "forwardagent": {}, "ciphers": {},
+	"hostkeyalgorithms": {}, "kexalgorithms": {},
+	"pubkeyauthentication": {}, "proxycommand": {},
+	"pubkeyacceptedalgorithms": {},
+}
 
 type SSHHostConfigGroup struct {
 	Comments []string
@@ -133,6 +143,9 @@ func groupFromTokens(tokens []lexer.Token) map[string]SSHHostConfigGroup {
 }
 
 func GroupSSHConfig(userInput string) ([]Define.HostConfig, error) {
+	if err := validateLegacySSHConfig(userInput); err != nil {
+		return nil, err
+	}
 	configs, err := GroupSSHConfigFromString(userInput)
 	if err != nil {
 		return nil, err
@@ -157,6 +170,73 @@ func GroupSSHConfig(userInput string) ([]Define.HostConfig, error) {
 		})
 	}
 	return hostConfigs, nil
+}
+
+func validateLegacySSHConfig(input string) error {
+	doc, err := sshconfig.Parse([]byte(input))
+	if err != nil {
+		return err
+	}
+	if diagnostics := doc.Diagnostics(); len(diagnostics) > 0 {
+		first := diagnostics[0]
+		return legacyLossError(first.Position.Line, first.Message)
+	}
+
+	hosts := make(map[string]struct{})
+	var directives map[string]struct{}
+	for _, node := range doc.Nodes() {
+		if node.Kind == sshconfig.NodeInvalid {
+			return legacyLossError(nodeLine(node), "malformed directive")
+		}
+		if node.Kind != sshconfig.NodeDirective || node.Directive == nil {
+			continue
+		}
+
+		directive := node.Directive
+		line := directive.Keyword.Position.Line
+		switch directive.KeywordValue {
+		case "host":
+			if len(directive.Arguments) == 0 {
+				return legacyLossError(line, "Host requires at least one pattern")
+			}
+			patterns := make([]string, 0, len(directive.Arguments))
+			for _, argument := range directive.Arguments {
+				patterns = append(patterns, argument.Value)
+			}
+			host := strings.Join(patterns, " ")
+			if _, exists := hosts[host]; exists {
+				return legacyLossError(line, fmt.Sprintf("duplicate Host block %q", host))
+			}
+			hosts[host] = struct{}{}
+			directives = make(map[string]struct{})
+			continue
+		case "match", "include":
+			return legacyLossError(line, fmt.Sprintf("%s cannot be represented", directive.KeywordValue))
+		}
+
+		if directives == nil {
+			return legacyLossError(line, "global directives before the first Host cannot be represented")
+		}
+		if _, supported := legacySSHDirectives[directive.KeywordValue]; !supported {
+			return legacyLossError(line, fmt.Sprintf("directive %q is not supported by the legacy schema", directive.KeywordValue))
+		}
+		if _, repeated := directives[directive.KeywordValue]; repeated {
+			return legacyLossError(line, fmt.Sprintf("repeated directive %q cannot be represented", directive.KeywordValue))
+		}
+		directives[directive.KeywordValue] = struct{}{}
+	}
+	return nil
+}
+
+func legacyLossError(line int, reason string) error {
+	return fmt.Errorf("legacy conversion would lose data at line %d: %s; use -lossless", line, reason)
+}
+
+func nodeLine(node sshconfig.Node) int {
+	if node.Directive != nil {
+		return node.Directive.Keyword.Position.Line
+	}
+	return 1
 }
 
 type SSHHostConfigGrouped struct {

--- a/internal/parser/yaml.go
+++ b/internal/parser/yaml.go
@@ -121,7 +121,15 @@ type YAMLHostConfigGroup struct {
 }
 
 func GroupYAMLConfig(input string) []Define.HostConfig {
-	yamlConfig := Fn.GetYamlData(input)
+	hostConfigs, _ := GroupYAMLConfigStrict(input)
+	return hostConfigs
+}
+
+func GroupYAMLConfigStrict(input string) ([]Define.HostConfig, error) {
+	yamlConfig, err := Fn.GetYamlDataStrict(input)
+	if err != nil {
+		return nil, fmt.Errorf("decode legacy YAML: %w", err)
+	}
 
 	var hostConfigs []Define.HostConfig
 
@@ -184,5 +192,5 @@ func GroupYAMLConfig(input string) []Define.HostConfig {
 			}
 		}
 	}
-	return hostConfigs
+	return hostConfigs, nil
 }

--- a/main.go
+++ b/main.go
@@ -78,7 +78,11 @@ func Run(args Cmd.Args, deps Dependencies) error {
 		userInput = string(content)
 	}
 
-	fileType := Fn.DetectStringType(userInput)
+	fileType, err := Fn.DetectStringTypeStrict(userInput)
+	if err != nil {
+		deps.Println("Error detecting config format:", err)
+		return err
+	}
 	result, err := deps.Process(fileType, userInput, args)
 	if err != nil {
 		deps.Println("Error parsing config:", err)
@@ -124,15 +128,16 @@ func Run(args Cmd.Args, deps Dependencies) error {
 }
 
 func MainWithDependencies(exit func(int), userHomeDir func() (string, error)) {
+	atomicSave := func(path string, data []byte) error {
+		return sshconfig.SaveAtomic(path, data, sshconfig.SaveOptions{PreserveMode: true})
+	}
 	deps := Dependencies{
-		StdinStat:  os.Stdin.Stat,
-		Exit:       os.Exit,
-		Println:    fmt.Println,
-		GetContent: Fn.GetPathContent,
-		SaveFile:   Fn.Save,
-		SaveLossless: func(path string, data []byte) error {
-			return sshconfig.SaveAtomic(path, data, sshconfig.SaveOptions{PreserveMode: true})
-		},
+		StdinStat:             os.Stdin.Stat,
+		Exit:                  os.Exit,
+		Println:               fmt.Println,
+		GetContent:            Fn.GetPathContent,
+		SaveFile:              atomicSave,
+		SaveLossless:          atomicSave,
 		GetUserInputFromStdin: Fn.GetUserInputFromStdin,
 		GetLosslessStdin:      func() ([]byte, error) { return io.ReadAll(os.Stdin) },
 		WriteOutput: func(data []byte) error {


### PR DESCRIPTION
## Summary

- propagate legacy YAML and JSON decode errors instead of converting malformed input to an empty document
- classify malformed structured input without falling back to SSH syntax
- reject legacy SSH conversions that cannot represent global directives, Match, Include, duplicate hosts, repeated directives, unknown directives, or malformed quoting
- point users to `-lossless` for configurations that require the v3 concrete syntax tree
- use the atomic writer for destination files in both legacy and lossless modes

## Why

The v2 map schema cannot represent ordering, repeated directives, Match blocks, Include boundaries, or arbitrary OpenSSH keywords. Previously these inputs could exit successfully while silently dropping or reassigning configuration.

## Verification

- `go test ./...`
- `go test -race ./...`
- `git diff --check`

## Compatibility

Representable v2 YAML, JSON, and SSH inputs keep their existing output. Inputs that previously lost data now return an actionable error.