### PR TITLE
fix: preserve invalid schema nodes and final newlines

### DIFF
--- a/pkg/sshconfig/schema.go
+++ b/pkg/sshconfig/schema.go
@@ -60,7 +60,11 @@ func (d *Document) ToSchema(path string) (SchemaDocument, error) {
 			Type:      schemaNodeType(node.Kind),
 			RawBase64: base64.StdEncoding.EncodeToString(raw),
 		}
-		if node.Directive != nil && utf8.Valid(raw) {
+		// Invalid nodes may carry a partially parsed Directive internally so
+		// diagnostics can point at tokens. They must remain raw-only in the
+		// schema: exposing an incomplete editable view violates the node shape
+		// contract and can discard the malformed bytes when reconstructed.
+		if node.Kind == NodeDirective && node.Directive != nil && utf8.Valid(raw) {
 			directive := node.Directive
 			arguments := make([]string, 0, len(directive.Arguments))
 			for _, argument := range directive.Arguments {
@@ -118,7 +122,7 @@ func (s SchemaDocument) Document() (*Document, error) {
 			output.Write(raw)
 			continue
 		}
-		output.Write(renderSchemaDirective(node.Directive, detectLineEnding(raw)))
+		output.Write(renderSchemaDirective(node.Directive, detectLineEnding(raw), len(raw) == 0))
 	}
 	return Parse(output.Bytes())
 }
@@ -262,8 +266,8 @@ func schemaRawMatchesDirective(raw []byte, expected *SchemaDirective) bool {
 	return reflect.DeepEqual(actual, expected)
 }
 
-func renderSchemaDirective(directive *SchemaDirective, lineEnding string) []byte {
-	if lineEnding == "" {
+func renderSchemaDirective(directive *SchemaDirective, lineEnding string, defaultLineEnding bool) []byte {
+	if lineEnding == "" && defaultLineEnding {
 		lineEnding = "\n"
 	}
 	var output bytes.Buffer

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -74,6 +74,87 @@ func TestSchemaRendersOnlyChangedDirective(t *testing.T) {
 	}
 }
 
+func TestSchemaPreservesInvalidNodesAsRawBytes(t *testing.T) {
+	t.Parallel()
+	input := []byte("Host example\n  ProxyCommand \"unterminated\n")
+	doc, _ := Parse(input)
+	if len(doc.Diagnostics()) == 0 {
+		t.Fatal("test input did not produce a diagnostic")
+	}
+
+	schemaDocument, err := doc.ToSchema("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if schemaDocument.Nodes[1].Type != "invalid" || schemaDocument.Nodes[1].Directive != nil {
+		t.Fatalf("invalid schema node = %#v, want raw-only invalid node", schemaDocument.Nodes[1])
+	}
+	schema := NewSchema(schemaDocument)
+	if err := schema.Validate(); err != nil {
+		t.Fatalf("exported schema does not validate: %v", err)
+	}
+
+	jsonData, err := MarshalSchemaJSON(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromJSON, err := UnmarshalSchemaJSON(jsonData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSchemaDocumentBytes(t, fromJSON, "config", input)
+
+	yamlData, err := MarshalSchemaYAML(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromYAML, err := UnmarshalSchemaYAML(yamlData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSchemaDocumentBytes(t, fromYAML, "config", input)
+}
+
+func TestSchemaEditPreservesMissingFinalNewline(t *testing.T) {
+	t.Parallel()
+	input := []byte("Host example\n  User old")
+	doc, _ := Parse(input)
+	schemaDocument, err := doc.ToSchema("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	schemaDocument.Nodes[1].Directive.Arguments = []string{"new"}
+
+	reconstructed, err := schemaDocument.Document()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := reconstructed.MarshalPreserve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte("Host example\nUser new")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestSchemaNewDirectiveDefaultsToLF(t *testing.T) {
+	t.Parallel()
+	schemaDocument := SchemaDocument{Nodes: []SchemaNode{{
+		Type:      "directive",
+		Directive: &SchemaDirective{Keyword: "Host", Arguments: []string{"example"}},
+	}}}
+	doc, err := schemaDocument.Document()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := doc.MarshalPreserve()
+	if want := []byte("Host example\n"); !bytes.Equal(got, want) {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
 func TestSchemaStrictValidation(t *testing.T) {
 	t.Parallel()
 	if _, err := UnmarshalSchemaJSON([]byte(`{"schemaVersion":3,"documents":[],"extra":true}`)); err == nil {


### PR DESCRIPTION
## Summary

- export malformed parser nodes as raw-only v3 schema nodes instead of attaching an incomplete directive view
- keep edited final directives unterminated when the original file had no final newline
- continue defaulting brand-new directive nodes without raw bytes to LF
- cover JSON and YAML round trips for malformed input

## Why

Invalid nodes retain a partial internal directive for diagnostics, but exposing it as editable schema data violates the v3 node shape and can discard malformed source bytes. Separately, editing the final directive previously added a newline that did not exist in the source.

## Verification

- `go test ./...`
- `go test -race ./...`
- `git diff --check`

## Independence

This PR is based directly on `main` and has no dependency on #19.