### PR TITLE
fix: match OpenSSH argv quoting semantics

### DIFF
--- a/pkg/sshconfig/openssh_integration_test.go
+++ b/pkg/sshconfig/openssh_integration_test.go
@@ -90,6 +90,48 @@ func TestOpenSSHAcceptsSupportedLexicalForms(t *testing.T) {
 	}
 }
 
+func TestOpenSSHArgvSemanticsSurviveCanonicalRewrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("OpenSSH integration fixture uses POSIX file permissions")
+	}
+	ssh, err := exec.LookPath("ssh")
+	if err != nil {
+		t.Skip("OpenSSH client is not installed")
+	}
+	t.Parallel()
+
+	directory := t.TempDir()
+	original := filepath.Join(directory, "original.conf")
+	generated := filepath.Join(directory, "generated.conf")
+	content := []byte("Host example\n" +
+		`    SetEnv FIRST=one" two" SECOND='three'four THIRD=hash#tag FOUR=quote\"mark` + "\n")
+	writeTestConfig(t, original, string(content))
+
+	doc, err := Parse(content)
+	if err != nil || len(doc.Diagnostics()) != 0 {
+		t.Fatalf("Parse() = %v, diagnostics = %#v", err, doc.Diagnostics())
+	}
+	node := doc.Nodes()[1]
+	arguments := make([]string, 0, len(node.Directive.Arguments))
+	for _, argument := range node.Directive.Arguments {
+		arguments = append(arguments, argument.Value)
+	}
+	if err := doc.ReplaceDirective(node.ID, "SetEnv", arguments...); err != nil {
+		t.Fatal(err)
+	}
+	output, err := doc.MarshalPreserve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTestConfig(t, generated, string(output))
+
+	originalOutput := runSSHConfig(t, ssh, directory, original, "example")
+	generatedOutput := runSSHConfig(t, ssh, directory, generated, "example")
+	if !bytes.Equal(originalOutput, generatedOutput) {
+		t.Fatalf("effective configuration changed after canonical rewrite\n--- original ---\n%s\n--- generated ---\n%s\n--- rewritten source ---\n%s", originalOutput, generatedOutput, output)
+	}
+}
+
 func runSSHConfig(t *testing.T, ssh, home, config, host string) []byte {
 	t.Helper()
 	command := exec.Command(ssh, "-G", "-F", config, host)

--- a/pkg/sshconfig/parser.go
+++ b/pkg/sshconfig/parser.go
@@ -94,7 +94,9 @@ func parseArguments(doc *Document, line, lineStart, start, end int) ([]Argument,
 	var arguments []Argument
 	i := start
 	for {
-		i = skipHorizontalSpace(doc.source, i, end)
+		for i < end && isArgumentSpace(doc.source[i]) {
+			i++
+		}
 		if i >= end {
 			return arguments, nil, false
 		}
@@ -109,31 +111,37 @@ func parseArguments(doc *Document, line, lineStart, start, end int) ([]Argument,
 		argumentStart := i
 		quote := QuoteNone
 		quoteByte := byte(0)
-		if doc.source[i] == '\'' || doc.source[i] == '"' {
-			quoteByte = doc.source[i]
-			if quoteByte == '\'' {
-				quote = QuoteSingle
-			} else {
-				quote = QuoteDouble
-			}
-			i++
-		}
-
 		value := make([]byte, 0, end-i)
-		closed := quoteByte == 0
 		for i < end {
 			ch := doc.source[i]
+			if ch == '\\' {
+				if i+1 < end && isEscapable(doc.source[i+1], quoteByte) {
+					i++
+					value = append(value, doc.source[i])
+					i++
+					continue
+				}
+				value = append(value, ch)
+				i++
+				continue
+			}
+			if quoteByte == 0 && isArgumentSpace(ch) {
+				break
+			}
+			if quoteByte == 0 && (ch == '\'' || ch == '"') {
+				quoteByte = ch
+				if quote == QuoteNone {
+					if ch == '\'' {
+						quote = QuoteSingle
+					} else {
+						quote = QuoteDouble
+					}
+				}
+				i++
+				continue
+			}
 			if quoteByte != 0 && ch == quoteByte {
-				i++
-				closed = true
-				break
-			}
-			if quoteByte == 0 && isHorizontalSpace(ch) {
-				break
-			}
-			if ch == '\\' && i+1 < end && isEscapable(doc.source[i+1], quoteByte) {
-				i++
-				value = append(value, doc.source[i])
+				quoteByte = 0
 				i++
 				continue
 			}
@@ -141,15 +149,9 @@ func parseArguments(doc *Document, line, lineStart, start, end int) ([]Argument,
 			i++
 		}
 
-		if !closed {
+		if quoteByte != 0 {
 			doc.addDiagnostic(line, argumentStart-lineStart+1, argumentStart, "unterminated quoted argument")
 			return arguments, nil, true
-		}
-		if quoteByte != 0 && i < end && !isHorizontalSpace(doc.source[i]) && doc.source[i] != '#' {
-			for i < end && !isHorizontalSpace(doc.source[i]) {
-				value = append(value, doc.source[i])
-				i++
-			}
 		}
 		arguments = append(arguments, Argument{
 			Token: Token{
@@ -160,6 +162,10 @@ func parseArguments(doc *Document, line, lineStart, start, end int) ([]Argument,
 			Quote: quote,
 		})
 	}
+}
+
+func isArgumentSpace(ch byte) bool {
+	return ch == ' ' || ch == '\t'
 }
 
 func (d *Document) addDiagnostic(line, column, offset int, message string) {

--- a/pkg/sshconfig/parser_test.go
+++ b/pkg/sshconfig/parser_test.go
@@ -88,6 +88,45 @@ func TestMalformedQuoteIsRetainedAndDiagnosed(t *testing.T) {
 	}
 }
 
+func TestParseArgumentsMatchesOpenSSHArgvSplit(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{name: "mid token quotes", input: `SetEnv foo" bar"baz`, want: []string{"foo barbaz"}},
+		{name: "adjacent quotes", input: `SetEnv "one"'two'"three"`, want: []string{"onetwothree"}},
+		{name: "escaped quotes", input: `SetEnv one\"two one\'three`, want: []string{`one"two`, "one'three"}},
+		{name: "escaped space outside quotes", input: `SetEnv one\ two`, want: []string{"one two"}},
+		{name: "escaped space inside quotes", input: `SetEnv "one\ two"`, want: []string{`one\ two`}},
+		{name: "unrecognized escape", input: `SetEnv one\q`, want: []string{`one\q`}},
+		{name: "hash in token", input: `SetEnv value#literal # comment`, want: []string{"value#literal"}},
+		{name: "form feed is not argv whitespace", input: "SetEnv one\ftwo", want: []string{"one\ftwo"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			doc, err := Parse([]byte(test.input + "\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diagnostics := doc.Diagnostics(); len(diagnostics) != 0 {
+				t.Fatalf("diagnostics = %#v", diagnostics)
+			}
+			directive := doc.Nodes()[0].Directive
+			got := make([]string, 0, len(directive.Arguments))
+			for _, argument := range directive.Arguments {
+				got = append(got, argument.Value)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("arguments = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestParseFile(t *testing.T) {
 	t.Parallel()
 	doc, err := ParseFile("config", func(path string) ([]byte, error) {


### PR DESCRIPTION
## Summary

- implement OpenSSH-style quote transitions anywhere inside an argument
- concatenate adjacent quoted and unquoted fragments into one value
- consume only the escape sequences recognized by OpenSSH
- treat only space and tab as argv separators
- preserve a mid-token `#` literally while recognizing comments at token boundaries
- add table-driven lexical tests and an `ssh -G` semantic differential test

## Upstream reference

The state machine follows [openssh-portable `misc.c::argv_split`](https://github.com/openssh/openssh-portable/blob/master/misc.c): quotes toggle within a token, recognized escapes are removed, and only space/tab terminate an unquoted token.

## Verification

- `go test ./pkg/sshconfig -run 'TestParseArgumentsMatchesOpenSSHArgvSplit|TestOpenSSHArgvSemanticsSurviveCanonicalRewrite' -v`
- `go test ./...`
- `go test -race ./...`
- `git diff --check`

## Dependency

Based on #19 because that PR was already merged into `main`. It does not depend on #20.