### PR TITLE
fix: make CLI help version and errors exact

### DIFF
--- a/cmd/argv.go
+++ b/cmd/argv.go
@@ -38,6 +38,7 @@ type Args struct {
 	Src      string
 	Dest     string
 	ShowHelp bool
+	Version  bool
 }
 
 const (
@@ -48,6 +49,7 @@ const (
 	DEFAULT_SRC      = ""
 	DEFAULT_DEST     = ""
 	DEFAULT_HELP     = false
+	DEFAULT_VERSION  = false
 )
 
 func initFlags() {
@@ -58,6 +60,7 @@ func initFlags() {
 	flag.StringVar(&args.Src, "src", DEFAULT_SRC, "Source file or directories path, valid when using non-pipeline mode")
 	flag.StringVar(&args.Dest, "dest", DEFAULT_DEST, "Destination file path, valid when using non-pipeline mode")
 	flag.BoolVar(&args.ShowHelp, "help", DEFAULT_HELP, "Show help")
+	flag.BoolVar(&args.Version, "version", DEFAULT_VERSION, "Show version")
 }
 
 func ParseArgs() Args {
@@ -78,6 +81,7 @@ func ResetFlags() {
 		Src:      DEFAULT_SRC,
 		Dest:     DEFAULT_DEST,
 		ShowHelp: DEFAULT_HELP,
+		Version:  DEFAULT_VERSION,
 	} // Reset the args
 	once = sync.Once{} // Reset the once
 }
@@ -85,7 +89,7 @@ func ResetFlags() {
 func CheckUseStdin(osStdinStat func() (fs.FileInfo, error)) bool {
 	fi, err := osStdinStat()
 	if err != nil {
-		fmt.Println("Error getting stdin stat:", err)
+		fmt.Fprintln(os.Stderr, "Error getting stdin stat:", err)
 		return false
 	}
 	if (fi.Mode() & os.ModeCharDevice) == 0 {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -261,11 +261,12 @@ func TestParseArgs(t *testing.T) {
 				Src:      Cmd.DEFAULT_SRC,
 				Dest:     Cmd.DEFAULT_DEST,
 				ShowHelp: Cmd.DEFAULT_HELP,
+				Version:  Cmd.DEFAULT_VERSION,
 			},
 		},
 		{
 			name: "Set all flags",
-			args: []string{"-to-yaml", "-to-ssh", "-to-json", "-lossless", "-src", "source.txt", "-dest", "destination.txt", "-help"},
+			args: []string{"-to-yaml", "-to-ssh", "-to-json", "-lossless", "-src", "source.txt", "-dest", "destination.txt", "-help", "-version"},
 			expected: Cmd.Args{
 				ToYAML:   true,
 				ToSSH:    true,
@@ -274,6 +275,7 @@ func TestParseArgs(t *testing.T) {
 				Src:      "source.txt",
 				Dest:     "destination.txt",
 				ShowHelp: true,
+				Version:  true,
 			},
 		},
 		{

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -26,6 +26,7 @@ const Usage = `Usage:
   ssh-config -lossless -to-ssh -src <v3 YAML or JSON file>
   ssh-config -src <source file or directories path> -dest <destination file path>
   ssh-config -help
+  ssh-config -version
 `
 
 func ShowHelp() {

--- a/main.go
+++ b/main.go
@@ -28,10 +28,19 @@ import (
 	"github.com/soulteary/ssh-config/v2/pkg/sshconfig"
 )
 
+var (
+	version   = "dev"
+	commit    = "none"
+	date      = "unknown"
+	builtBy   = "unknown"
+	treeState = "unknown"
+)
+
 type Dependencies struct {
 	StdinStat             func() (os.FileInfo, error)
 	Exit                  func(int)
 	Println               func(...interface{}) (n int, err error)
+	PrintErr              func(...interface{}) (n int, err error)
 	GetContent            func(string) ([]byte, error)
 	SaveFile              func(string, []byte) error
 	SaveLossless          func(string, []byte) error
@@ -46,7 +55,7 @@ type Dependencies struct {
 func Run(args Cmd.Args, deps Dependencies) error {
 	isValid, notValidReason := Cmd.CheckConvertArgvValid(args)
 	if !isValid {
-		deps.Println(notValidReason)
+		deps.errorln(notValidReason)
 		return fmt.Errorf("%s", notValidReason)
 	}
 
@@ -56,7 +65,7 @@ func Run(args Cmd.Args, deps Dependencies) error {
 		if args.Lossless && deps.GetLosslessStdin != nil {
 			input, err := deps.GetLosslessStdin()
 			if err != nil {
-				deps.Println("Error reading stdin:", err)
+				deps.errorln("Error reading stdin:", err)
 				return err
 			}
 			userInput = string(input)
@@ -66,13 +75,13 @@ func Run(args Cmd.Args, deps Dependencies) error {
 	} else {
 		isValid, notValidReason := Cmd.CheckIOArgvValid(args)
 		if !isValid {
-			deps.Println(notValidReason)
+			deps.errorln(notValidReason)
 			return fmt.Errorf("%s", notValidReason)
 		}
 
 		content, err := deps.GetContent(args.Src)
 		if err != nil {
-			deps.Println("Error reading file:", err)
+			deps.errorln("Error reading file:", err)
 			return err
 		}
 		userInput = string(content)
@@ -80,19 +89,19 @@ func Run(args Cmd.Args, deps Dependencies) error {
 
 	fileType, err := Fn.DetectStringTypeStrict(userInput)
 	if err != nil {
-		deps.Println("Error detecting config format:", err)
+		deps.errorln("Error detecting config format:", err)
 		return err
 	}
 	result, err := deps.Process(fileType, userInput, args)
 	if err != nil {
-		deps.Println("Error parsing config:", err)
+		deps.errorln("Error parsing config:", err)
 		return err
 	}
 
 	if pipeMode {
 		if args.Lossless && deps.WriteOutput != nil {
 			if err := deps.WriteOutput(result); err != nil {
-				deps.Println("Error writing output:", err)
+				deps.errorln("Error writing output:", err)
 				return err
 			}
 		} else {
@@ -102,7 +111,7 @@ func Run(args Cmd.Args, deps Dependencies) error {
 		if args.Dest == "" {
 			if args.Lossless && deps.WriteOutput != nil {
 				if err := deps.WriteOutput(result); err != nil {
-					deps.Println("Error writing output:", err)
+					deps.errorln("Error writing output:", err)
 					return err
 				}
 			} else {
@@ -117,7 +126,7 @@ func Run(args Cmd.Args, deps Dependencies) error {
 		}
 		err := save(args.Dest, result)
 		if err != nil {
-			deps.Println("Error saving file:", err)
+			deps.errorln("Error saving file:", err)
 			return err
 		}
 		deps.Println("File has been saved successfully")
@@ -127,14 +136,31 @@ func Run(args Cmd.Args, deps Dependencies) error {
 	return nil
 }
 
+func (deps Dependencies) errorln(values ...interface{}) {
+	if deps.PrintErr != nil {
+		_, _ = deps.PrintErr(values...)
+		return
+	}
+	if deps.Println != nil {
+		_, _ = deps.Println(values...)
+	}
+}
+
+func versionText() string {
+	return fmt.Sprintf("ssh-config %s (commit %s, built %s by %s, tree state %s)\n", version, commit, date, builtBy, treeState)
+}
+
 func MainWithDependencies(exit func(int), userHomeDir func() (string, error)) {
 	atomicSave := func(path string, data []byte) error {
 		return sshconfig.SaveAtomic(path, data, sshconfig.SaveOptions{PreserveMode: true})
 	}
 	deps := Dependencies{
-		StdinStat:             os.Stdin.Stat,
-		Exit:                  os.Exit,
-		Println:               fmt.Println,
+		StdinStat: os.Stdin.Stat,
+		Exit:      os.Exit,
+		Println:   fmt.Println,
+		PrintErr: func(values ...interface{}) (int, error) {
+			return fmt.Fprintln(os.Stderr, values...)
+		},
 		GetContent:            Fn.GetPathContent,
 		SaveFile:              atomicSave,
 		SaveLossless:          atomicSave,
@@ -148,13 +174,22 @@ func MainWithDependencies(exit func(int), userHomeDir func() (string, error)) {
 		CheckUseStdin: func() bool { return Cmd.CheckUseStdin(os.Stdin.Stat) },
 	}
 	args := Cmd.ParseArgs()
+	if args.ShowHelp {
+		fmt.Print(Cmd.Usage)
+		return
+	}
+	if args.Version {
+		fmt.Print(versionText())
+		return
+	}
 
 	// default src to ~/.ssh
 	if args.Src == "" {
 		homeDir, err := userHomeDir()
 		if err != nil {
-			fmt.Println("Error: getting user home directory:", err)
+			fmt.Fprintln(os.Stderr, "Error: getting user home directory:", err)
 			exit(1)
+			return
 		}
 		args.Src = filepath.Join(homeDir, ".ssh")
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -246,6 +246,7 @@ func TestMainWithDependencies(t *testing.T) {
 		name           string
 		args           []string
 		expectedOutput string
+		expectedError  string
 		expectedExit   int
 		mockHomeDir    func() (string, error)
 	}{
@@ -264,19 +265,37 @@ func TestMainWithDependencies(t *testing.T) {
 			mockHomeDir:    os.UserHomeDir,
 		},
 		{
-			name:           "Error execution",
-			args:           []string{"cmd", "--to-json", "--to-yaml"}, // Invalid args
-			expectedOutput: "Please specify either -to-yaml or -to-ssh or -to-json\n",
-			expectedExit:   1,
-			mockHomeDir:    os.UserHomeDir,
+			name:          "Error execution",
+			args:          []string{"cmd", "--to-json", "--to-yaml"}, // Invalid args
+			expectedError: "Please specify either -to-yaml or -to-ssh or -to-json\n",
+			expectedExit:  1,
+			mockHomeDir:   os.UserHomeDir,
 		},
 		{
-			name:           "Home directory error",
-			args:           []string{"cmd"}, // No src specified, will try to use home dir
-			expectedOutput: "Error: getting user home directory: mock home dir error\nError: Source path '.ssh' does not exist\n",
-			expectedExit:   1,
+			name:          "Home directory error",
+			args:          []string{"cmd"}, // No src specified, will try to use home dir
+			expectedError: "Error: getting user home directory: mock home dir error\n",
+			expectedExit:  1,
 			mockHomeDir: func() (string, error) {
 				return "", errors.New("mock home dir error")
+			},
+		},
+		{
+			name:           "Help exits before IO",
+			args:           []string{"cmd", "-help"},
+			expectedOutput: Cmd.Usage,
+			expectedExit:   0,
+			mockHomeDir: func() (string, error) {
+				return "", errors.New("home must not be queried")
+			},
+		},
+		{
+			name:           "Version exits before IO",
+			args:           []string{"cmd", "-version"},
+			expectedOutput: versionText(),
+			expectedExit:   0,
+			mockHomeDir: func() (string, error) {
+				return "", errors.New("home must not be queried")
 			},
 		},
 	}
@@ -291,23 +310,30 @@ func TestMainWithDependencies(t *testing.T) {
 			}
 
 			oldStdout := os.Stdout
-			r, w, _ := os.Pipe()
-			os.Stdout = w
+			stdoutR, stdoutW, _ := os.Pipe()
+			oldStderr := os.Stderr
+			stderrR, stderrW, _ := os.Pipe()
+			os.Stdout = stdoutW
+			os.Stderr = stderrW
 
 			MainWithDependencies(exitFunc, tt.mockHomeDir)
 			Cmd.ResetFlags()
 
-			w.Close()
+			stdoutW.Close()
+			stderrW.Close()
 			os.Stdout = oldStdout
+			os.Stderr = oldStderr
 
-			var buf bytes.Buffer
-			io.Copy(&buf, r)
-			output := buf.String()
+			var stdout, stderr bytes.Buffer
+			io.Copy(&stdout, stdoutR)
+			io.Copy(&stderr, stderrR)
+			output := stdout.String()
 
 			if output != tt.expectedOutput {
-				if tt.name != "Error execution" {
-					t.Errorf("Output = %q, want %q", output, tt.expectedOutput)
-				}
+				t.Errorf("Output = %q, want %q", output, tt.expectedOutput)
+			}
+			if got := stderr.String(); got != tt.expectedError {
+				t.Errorf("Stderr = %q, want %q", got, tt.expectedError)
 			}
 
 			if exitCode != tt.expectedExit {


### PR DESCRIPTION
## Summary

- make `-help` return before home-directory lookup, conversion defaults, stdin inspection, or file IO
- add `-version` output backed by the metadata already injected by GoReleaser
- route diagnostics to stderr while keeping converted data and success messages on stdout
- return immediately after a mocked or real fatal exit path
- route stdin-stat diagnostics to stderr
- add exact stdout, stderr, version, help, and exit-code regression tests

## Verification

- `go test ./...`
- `go test -race ./...`
- build with all GoReleaser `-X main.*` variables and run `-version`
- run `-help` before any IO
- `git diff --check`

## Independence

Based on merged #19. It does not depend on #20 or #21.