### PR TITLE
fix: make atomic saves durable and testable

### DIFF
--- a/pkg/sshconfig/syncdir_unix.go
+++ b/pkg/sshconfig/syncdir_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package sshconfig
+
+import "os"
+
+// syncDirectory makes the rename durable across a crash on filesystems that
+// require the containing directory entry to be flushed separately.
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}

--- a/pkg/sshconfig/syncdir_windows.go
+++ b/pkg/sshconfig/syncdir_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package sshconfig
+
+// Windows does not support syncing a directory handle opened through os.Open.
+// The temporary file itself is synced before the atomic rename.
+func syncDirectory(string) error {
+	return nil
+}

--- a/pkg/sshconfig/writer.go
+++ b/pkg/sshconfig/writer.go
@@ -39,6 +39,32 @@ type SaveOptions struct {
 	PreserveMode bool
 }
 
+type atomicFile interface {
+	Name() string
+	Chmod(fs.FileMode) error
+	Write([]byte) (int, error)
+	Sync() error
+	Close() error
+}
+
+type atomicWriteOperations struct {
+	lstat         func(string) (fs.FileInfo, error)
+	createTemp    func(string, string) (atomicFile, error)
+	rename        func(string, string) error
+	remove        func(string) error
+	syncDirectory func(string) error
+}
+
+var defaultAtomicWriteOperations = atomicWriteOperations{
+	lstat: os.Lstat,
+	createTemp: func(directory, pattern string) (atomicFile, error) {
+		return os.CreateTemp(directory, pattern)
+	},
+	rename:        os.Rename,
+	remove:        os.Remove,
+	syncDirectory: syncDirectory,
+}
+
 // Save atomically writes a document to path. Symbolic-link destinations are
 // rejected so a caller cannot unintentionally replace a link target.
 func (d *Document) Save(path string, options SaveOptions) error {
@@ -52,6 +78,10 @@ func (d *Document) Save(path string, options SaveOptions) error {
 // SaveAtomic writes data to a temporary file in the destination directory,
 // syncs it, and atomically renames it over path.
 func SaveAtomic(path string, data []byte, options SaveOptions) error {
+	return saveAtomic(path, data, options, defaultAtomicWriteOperations)
+}
+
+func saveAtomic(path string, data []byte, options SaveOptions, operations atomicWriteOperations) error {
 	if path == "" {
 		return fmt.Errorf("sshconfig: destination path is empty")
 	}
@@ -59,7 +89,7 @@ func SaveAtomic(path string, data []byte, options SaveOptions) error {
 	if mode == 0 {
 		mode = 0600
 	}
-	if info, err := os.Lstat(path); err == nil {
+	if info, err := operations.lstat(path); err == nil {
 		if info.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("sshconfig: refusing symbolic-link destination %s", path)
 		}
@@ -74,7 +104,7 @@ func SaveAtomic(path string, data []byte, options SaveOptions) error {
 	}
 
 	directory := filepath.Dir(path)
-	temp, err := os.CreateTemp(directory, "."+filepath.Base(path)+".tmp-*")
+	temp, err := operations.createTemp(directory, "."+filepath.Base(path)+".tmp-*")
 	if err != nil {
 		return fmt.Errorf("sshconfig: create temporary file: %w", err)
 	}
@@ -84,7 +114,7 @@ func SaveAtomic(path string, data []byte, options SaveOptions) error {
 		if !closed {
 			_ = temp.Close()
 		}
-		_ = os.Remove(tempPath)
+		_ = operations.remove(tempPath)
 	}()
 
 	if err := temp.Chmod(mode); err != nil {
@@ -100,8 +130,11 @@ func SaveAtomic(path string, data []byte, options SaveOptions) error {
 		return fmt.Errorf("sshconfig: close temporary file: %w", err)
 	}
 	closed = true
-	if err := os.Rename(tempPath, path); err != nil {
+	if err := operations.rename(tempPath, path); err != nil {
 		return fmt.Errorf("sshconfig: replace destination %s: %w", path, err)
+	}
+	if err := operations.syncDirectory(directory); err != nil {
+		return fmt.Errorf("sshconfig: sync destination directory %s: %w", directory, err)
 	}
 	return nil
 }

--- a/pkg/sshconfig/writer_test.go
+++ b/pkg/sshconfig/writer_test.go
@@ -2,6 +2,8 @@ package sshconfig
 
 import (
 	"bytes"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -129,5 +131,96 @@ func TestSaveAtomicRejectsSymlink(t *testing.T) {
 	got, err := os.ReadFile(target)
 	if err != nil || string(got) != "unchanged" {
 		t.Fatalf("target changed: %q, %v", got, err)
+	}
+}
+
+type failingAtomicFile struct {
+	*os.File
+	failure string
+}
+
+func (f *failingAtomicFile) Chmod(mode fs.FileMode) error {
+	if f.failure == "chmod" {
+		return errors.New("injected chmod failure")
+	}
+	return f.File.Chmod(mode)
+}
+
+func (f *failingAtomicFile) Write(data []byte) (int, error) {
+	if f.failure == "write" {
+		return 0, errors.New("injected write failure")
+	}
+	return f.File.Write(data)
+}
+
+func (f *failingAtomicFile) Sync() error {
+	if f.failure == "sync" {
+		return errors.New("injected sync failure")
+	}
+	return f.File.Sync()
+}
+
+func (f *failingAtomicFile) Close() error {
+	err := f.File.Close()
+	if f.failure == "close" {
+		return errors.New("injected close failure")
+	}
+	return err
+}
+
+func TestSaveAtomicFailureBeforeRenameKeepsDestination(t *testing.T) {
+	t.Parallel()
+	for _, failure := range []string{"chmod", "write", "sync", "close", "rename"} {
+		failure := failure
+		t.Run(failure, func(t *testing.T) {
+			t.Parallel()
+			directory := t.TempDir()
+			path := filepath.Join(directory, "config")
+			if err := os.WriteFile(path, []byte("old"), 0600); err != nil {
+				t.Fatal(err)
+			}
+
+			operations := defaultAtomicWriteOperations
+			operations.createTemp = func(directory, pattern string) (atomicFile, error) {
+				file, err := os.CreateTemp(directory, pattern)
+				if err != nil {
+					return nil, err
+				}
+				return &failingAtomicFile{File: file, failure: failure}, nil
+			}
+			if failure == "rename" {
+				operations.rename = func(string, string) error { return errors.New("injected rename failure") }
+			}
+
+			if err := saveAtomic(path, []byte("new"), SaveOptions{}, operations); err == nil {
+				t.Fatal("saveAtomic() unexpectedly succeeded")
+			}
+			got, err := os.ReadFile(path)
+			if err != nil || string(got) != "old" {
+				t.Fatalf("destination = %q, %v; want unchanged", got, err)
+			}
+			matches, err := filepath.Glob(filepath.Join(directory, ".config.tmp-*"))
+			if err != nil || len(matches) != 0 {
+				t.Fatalf("temporary files remain: %v, %v", matches, err)
+			}
+		})
+	}
+}
+
+func TestSaveAtomicReportsDirectorySyncFailure(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	path := filepath.Join(directory, "config")
+	operations := defaultAtomicWriteOperations
+	syncErr := errors.New("injected directory sync failure")
+	operations.syncDirectory = func(string) error { return syncErr }
+
+	err := saveAtomic(path, []byte("new"), SaveOptions{}, operations)
+	if err == nil || !errors.Is(err, syncErr) {
+		t.Fatalf("saveAtomic() error = %v", err)
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil || string(got) != "new" {
+		t.Fatalf("renamed destination = %q, %v", got, readErr)
 	}
 }


### PR DESCRIPTION
## Summary

- fsync the containing directory after the atomic rename on supported platforms
- keep the existing file sync, mode preservation, symlink refusal, and same-directory temporary file behavior
- isolate filesystem operations behind a private operation set for deterministic failure injection
- verify chmod, write, file sync, close, and rename failures leave the original destination unchanged
- verify every pre-rename failure removes temporary files
- provide a Windows-specific directory-sync implementation and cross-compile it

## Durability semantics

A directory-sync failure is reported after rename: the new file is visible, but crash durability could not be confirmed. Failures before rename leave the old destination intact.

## Verification

- `go test ./pkg/sshconfig -run TestSaveAtomic -v`
- `go test ./...`
- `go test -race ./...`
- `GOOS=windows GOARCH=amd64 go test -exec=true ./pkg/sshconfig`
- `git diff --check`

## Independence

Based on merged #19; independent of #20–#22.