### PR TITLE
ci: restore pull request quality gates

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,7 +1,14 @@
 name: Run tests and upload coverage
 
-on: 
-  push
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 env:
   GO_VERSION: "1.26.0"
@@ -12,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -28,6 +35,9 @@ jobs:
         run: go test -v ./... -covermode=atomic -coverprofile=coverage.txt
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.txt
+          fail_ci_if_error: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,7 @@
 name: "CodeQL Advanced"
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
   pull_request:
@@ -32,11 +33,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@fddeee1a7ece751b577e409a89057319e3172939 # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -52,6 +53,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@fddeee1a7ece751b577e409a89057319e3172939 # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,56 @@
+name: Quality
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test, vet and vulnerability scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Verify module files
+        run: go mod tidy -diff
+
+      - name: Test with race detector
+        run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
+
+      - name: Scan dependencies
+        run: govulncheck ./...
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: coverage-${{ github.sha }}
+          path: coverage.out
+          if-no-files-found: error
+          retention-days: 7

--- a/internal/parser/define.go
+++ b/internal/parser/define.go
@@ -138,5 +138,4 @@ type HostConfig struct {
 
 	YamlUserNotes string `yaml:"YamlUserNotes,omitempty"`
 	YamlUserHost  string `yaml:"YamlUserHost,omitempty"`
-	YamlTested    string `yaml` // this is a placeholder for the test
 }


### PR DESCRIPTION
## Summary

- add a GitHub-hosted `ubuntu-latest` PR gate for race-enabled tests, coverage, `go vet`, and `govulncheck`
- fail when `go mod tidy -diff` detects uncommitted module changes
- retain the coverage profile as a short-lived Actions artifact
- fix the malformed placeholder struct tag that prevented repository-wide `go vet`
- add manual dispatch to CodeQL and pin first-party actions to immutable SHAs
- run Codecov on main and pull requests without making the third-party upload a merge blocker
- restrict workflow permissions and cancel superseded quality runs

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go mod tidy -diff`
- `govulncheck ./...` → no vulnerabilities found
- `git diff --check`

## Runner policy

Every job uses GitHub Actions-hosted `ubuntu-latest`; no self-hosted runner is introduced.

## Dependency

Based on merged #19–#22. Independent of #23.