### PR TITLE
build: upgrade to Go 1.27 and Alpine 3.24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,6 @@ on:
     tags:
       - "*.*.*"
 
-env:
-  GO_VERSION: "1.26.0"
-  GO111MODULE: on
-  DOCKER_CLI_EXPERIMENTAL: "enabled"
-
 permissions:
   contents: write
   id-token: write
@@ -23,23 +18,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
+          cache: true
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Cache Go modules
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -48,25 +44,26 @@ jobs:
 
       - name: Tests
         run: |
-          go mod tidy
+          go mod tidy -diff
           go test -v ./...
 
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         if: success() && startsWith(github.ref, 'refs/tags/')
         with:
           version: '~> v2'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,9 +10,6 @@ on:
 permissions:
   contents: read
 
-env:
-  GO_VERSION: "1.26.0"
-
 jobs:
   test:
     name: Run tests and collect coverage
@@ -26,7 +23,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
+          cache: true
 
       - name: Install dependencies
         run: go mod download

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,7 +29,7 @@ builds:
       - amd64
       - arm
       - arm64
-      - ppc64
+      - ppc64le
     goarm:
       - "7"
     ignore:
@@ -100,7 +100,7 @@ dockers_v2:
       io.artifacthub.package.logo-url: "https://raw.githubusercontent.com/soulteary/ssh-config/refs/heads/main/.github/github-repo-card.png"
       io.artifacthub.package.maintainers: '[{"name":"soulteary","email":"soulteary@gmail.com"}]'
       io.artifacthub.package.license: Apache-v2
-      org.opencontainers.image.description: "100% Coverage, Use more expressive YAML / JSON to manage your Config files."
+      org.opencontainers.image.description: "Losslessly parse, edit, and convert OpenSSH client configuration files."
       org.opencontainers.image.created: "{{ .Date }}"
       org.opencontainers.image.name: "{{ .ProjectName }}"
       org.opencontainers.image.revision: "{{ .FullCommit }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.20.0 as builder
-RUN apk --update add ca-certificates
+FROM alpine:3.24.1 AS builder
+RUN apk add --no-cache ca-certificates
 
-FROM alpine:3.20.0
-RUN apk --update add bash
+FROM alpine:3.24.1
+RUN apk add --no-cache bash
 LABEL maintainer "soulteary <soulteary@gmail.com>"
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ARG TARGETPLATFORM

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The previous YAML/JSON formats remain the default for compatibility. Lossless mo
 
 ### Dependencies
 
-- Go 1.26+
+- Go 1.27+
 
 ### Build
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -113,7 +113,7 @@ ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 
 ### 依赖
 
-- Go 1.26+
+- Go 1.27+
 
 ### 构建
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/soulteary/ssh-config/v2
 
-go 1.26.0
+go 1.27.0
 
 require gopkg.in/yaml.v2 v2.4.0


### PR DESCRIPTION
## Summary

- require Go 1.27.0 and make workflows read the toolchain version from `go.mod`
- upgrade both container stages to Alpine 3.24.1 and use `apk add --no-cache`
- replace the non-OCI `ppc64` release target with `ppc64le`
- pin every release workflow action to an immutable commit SHA
- avoid registry logins on non-tag main pushes
- make release builds verify `go mod tidy -diff` instead of modifying the checkout
- replace the stale “100% coverage” image label with the lossless parser description
- update English and Chinese development prerequisites

## Upstream versions

- [Go 1.27.0](https://go.dev/doc/devel/release) was released on 2026-08-19.
- Docker's [official Alpine image](https://hub.docker.com/_/alpine) lists `3.24.1` and supports `ppc64le`.

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- cross-compile tests for Linux/ppc64le, Windows/amd64, and Darwin/arm64
- `git diff --check`

## Dependency

Based on merged #24.