### PR TITLE
docs: formalize v3 schema and security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ cat /ssh/test.yaml | ssh-config -to-yaml
 - `-dest`: Specify the path to save the configuration file. When omitted, the converted result is written to standard output.
 - `-lossless`: Use the lossless parser and v3 YAML/JSON schema. This mode accepts one source file or stdin and writes destination files atomically.
 - `-help`: View program command-line help
+- `-version`: Print release, commit, build, and tree-state metadata
 
 ### Examples
 
@@ -122,6 +123,8 @@ ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 
 The previous YAML/JSON formats remain the default for compatibility. Lossless mode can import them, but ordering and repeated values already discarded by a legacy map cannot be reconstructed.
 
+See the [lossless schema v3 specification](./docs/lossless-schema-v3.md) for node shapes, byte-preservation rules, editing behavior, API examples, and migration limits.
+
 ## Development
 
 ### Dependencies
@@ -143,6 +146,8 @@ go test -v ./... -covermode=atomic -coverprofile=coverage.out && go tool cover -
 ## Contributing
 
 Issues and pull requests are welcome.
+
+Please report vulnerabilities through the private process in [SECURITY.md](./SECURITY.md), not through a public issue.
 
 ## License
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -78,6 +78,7 @@ cat /ssh/test.yaml | ssh-config -to-yaml
 - `-dest`: 指定要保存的配置文件路径
 - `-lossless`: 使用无损解析器和 v3 YAML/JSON 格式。此模式接受单个源文件或标准输入，并以原子方式写入目标文件。
 - `-help`: 查看程序命令行帮助
+- `-version`: 输出发布版本、提交、构建时间和工作树状态
 
 ### 示例
 
@@ -109,6 +110,8 @@ ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 
 为保持兼容，默认仍使用原有 YAML/JSON 格式。无损模式能够导入旧格式，但无法恢复已经被旧 map 结构丢弃的顺序和重复值。
 
+字段结构、字节保持规则、编辑行为、Go API 示例和旧格式迁移边界详见 [v3 无损格式规范](./docs/lossless-schema-v3.md)。
+
 ## 开发
 
 ### 依赖
@@ -130,6 +133,8 @@ go test -v ./... -covermode=atomic -coverprofile=coverage.out && go tool cover -
 ## 贡献
 
 欢迎提交 issues 和 pull requests。
+
+安全漏洞请按照 [SECURITY.md](./SECURITY.md) 中的私密流程报告，不要直接提交公开 issue。
 
 ## 许可证
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,25 +1,41 @@
-# Security Policy
+# Security policy
 
-## Supported Versions
+## Supported versions
 
-We welcome and support security vulnerability feedback for all versions of our project.
+| Version | Supported |
+| --- | --- |
+| Current `2.x` release and `main` | Yes |
+| Releases before `2.0.0` | No |
 
-| Version | Supported          |
-| ------- | ------------------ |
-| All versions | :white_check_mark: |
+Schema version `3` is a data-format version, not an application major version.
 
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
-We take the security of our project very seriously and welcome all types of security vulnerability feedback. If you discover any security issues, please report them using the following steps:
+Please report suspected vulnerabilities through a
+[private GitHub security advisory](https://github.com/soulteary/ssh-config/security/advisories/new).
+Do not open a public issue for an unpatched vulnerability.
 
-1. Go to the Issues page of our GitHub repository
-2. Click on "New issue" to create a new issue
-3. In the issue, provide a detailed description of the security vulnerability you've found, including:
-   - A detailed description of the vulnerability
-   - Steps to reproduce (if applicable)
-   - Affected versions
-   - Any other relevant information
+Include enough information to reproduce and assess the problem:
 
-Our team will review your submitted issue as soon as possible and may contact you for additional information if necessary.
+- affected release or commit;
+- operating system and architecture;
+- minimal configuration input and command line;
+- observed and expected behavior;
+- security impact and any known preconditions;
+- proof-of-concept code or logs with credentials, hostnames, keys, and tokens
+  removed.
 
-Thank you for your contribution to ensuring the security of our project!
+Relevant reports include unintended configuration loss or mutation, unsafe
+destination-file replacement, symbolic-link or path handling flaws, unexpected
+file access through `Include`, command execution, and parser resource-exhaustion
+issues.
+
+The maintainers will coordinate disclosure and remediation in the private
+advisory. Publish details only after a fixed release is available or the
+maintainers agree on a disclosure date.
+
+## Safe testing
+
+Use synthetic configuration files and accounts you control. Never include
+private keys, authentication agents, production hostnames, tokens, or other
+secrets in a report. Do not test against infrastructure without authorization.

--- a/docs/lossless-schema-v3.md
+++ b/docs/lossless-schema-v3.md
@@ -1,0 +1,131 @@
+# Lossless schema v3
+
+The v3 YAML/JSON schema is a transport and editing format for OpenSSH client
+configuration files. Its version number is independent of the application's
+semantic version and the Go module's `/v2` path.
+
+## Design guarantees
+
+- Parsing and exporting an unchanged document preserves every source byte.
+- Comments, blank lines, directive order, repeated directives, unknown
+  directives, line endings, quoting, spacing, and non-UTF-8 bytes remain in
+  `rawBase64`.
+- A malformed line is exported as a raw-only `invalid` node. Diagnostics do
+  not make the original bytes unavailable.
+- Editing one directive rewrites only that physical line. Other nodes are
+  copied from their original bytes.
+- An edited final line keeps its missing final newline. A brand-new directive
+  without raw bytes defaults to LF.
+
+The parser builds a concrete syntax tree; it does not evaluate host matching,
+expand tokens, follow `Include`, or execute `Match exec` while importing a
+document.
+
+## Envelope
+
+```yaml
+schemaVersion: 3
+documents:
+  - path: ~/.ssh/config
+    nodes:
+      - type: directive
+        rawBase64: SG9zdCBleGFtcGxlCg==
+        directive:
+          keyword: Host
+          arguments:
+            - example
+```
+
+The root fields are:
+
+- `schemaVersion`: must be the integer `3`.
+- `documents`: a non-empty array of physical source documents.
+
+Each document has an optional `path` and a `nodes` array. Non-empty paths must
+be unique. An empty selector can reconstruct a document only when the envelope
+contains exactly one document.
+
+JSON uses the same field names and shapes. Both decoders reject unknown fields,
+unsupported versions, duplicate paths, invalid Base64, trailing JSON values,
+and invalid node shapes.
+
+## Nodes
+
+Every node represents one physical source line and has one of these types:
+
+| Type | Editable directive | Meaning |
+| --- | --- | --- |
+| `blank` | no | Empty or whitespace-only line |
+| `comment` | no | Full-line comment |
+| `directive` | optional | Parsed OpenSSH directive |
+| `invalid` | no | Malformed line retained verbatim |
+
+`rawBase64` contains the complete physical line, including indentation,
+spacing, comments, and its line ending. Base64 is used so arbitrary source
+bytes survive YAML and JSON encoding.
+
+A directive view contains:
+
+- `keyword`: original keyword spelling;
+- `arguments`: decoded OpenSSH argument values;
+- `comment`: optional inline comment, normally including its leading `#`.
+
+Exported directive nodes contain both raw bytes and the editable view. If the
+view still describes the raw line exactly, reconstruction copies the raw bytes.
+If any semantic field changes, reconstruction renders that line canonically
+while retaining its original line-ending presence and style. A new directive
+may omit `rawBase64`; it is rendered canonically with LF.
+
+Blank nodes may represent an empty line without raw bytes. Every other
+non-directive node needs raw bytes. `comment` and `invalid` nodes never accept a
+directive view.
+
+## CLI workflow
+
+```bash
+ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+# Edit only directive.keyword, directive.arguments, or directive.comment.
+ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+```
+
+Use `-to-json` instead of `-to-yaml` for a JSON envelope. Destination files are
+replaced atomically; existing regular-file permissions are preserved, and
+symbolic-link destinations are rejected.
+
+## Go API
+
+```go
+doc, err := sshconfig.Parse(source)
+if err != nil {
+    return err
+}
+schemaDoc, err := doc.ToSchema("~/.ssh/config")
+if err != nil {
+    return err
+}
+encoded, err := sshconfig.MarshalSchemaYAML(sshconfig.NewSchema(schemaDoc))
+```
+
+Use `UnmarshalSchemaYAML` or `UnmarshalSchemaJSON` for strict decoding, then
+call `Schema.Document(path)` and `Document.MarshalPreserve()` to reconstruct
+SSH source.
+
+## Legacy migration
+
+Lossless mode accepts the previous map-based YAML and host-array JSON formats
+and migrates them deterministically into v3. Migration sorts map keys, applies
+legacy `Default` and `Common` values using the existing precedence rules, and
+emits a concrete v3 document.
+
+Migration cannot recover information that the legacy representation never
+stored, including directive order, duplicate keys, physical comments and
+spacing, `Match` structure, `Include` boundaries, or unknown directives that
+were discarded earlier. Keep an original SSH source file when exact recovery
+matters.
+
+## Versioning
+
+Readers must reject schema versions they do not support. Additive or breaking
+schema changes require a new `schemaVersion`; they must not be inferred from
+the application release number. Producers should preserve `rawBase64` and
+avoid rebuilding unchanged nodes from their semantic views.


### PR DESCRIPTION
## Summary

- specify the v3 envelope, document selection, node types, directive view, strict validation, and versioning rules
- document byte-preservation guarantees for raw, malformed, non-UTF-8, mixed-line-ending, and missing-final-newline input
- explain when an edited directive is canonically rendered and when original bytes remain authoritative
- provide CLI and Go API examples
- define deterministic legacy YAML/JSON migration behavior and the information it cannot recover
- replace the public-issue vulnerability process with private GitHub Security Advisories
- clarify supported application versions and that schema v3 is not application major version 3
- link the schema and security policies from both READMEs and document `-version`

## Verification

- `go test ./...`
- `git diff --check`
- verified every relative documentation link and both new files

## Dependency

Based on merged #25; no runtime code changes.