### PR TITLE
fix: close lossless CLI round trips

### DIFF
--- a/internal/parser/lossless.go
+++ b/internal/parser/lossless.go
@@ -60,7 +60,7 @@ func decodeLosslessInput(fileType string, data []byte) (sshconfig.Schema, bool, 
 		return schema, true, err
 	}
 
-	if strings.EqualFold(fileType, "YAML") {
+	if strings.EqualFold(fileType, "YAML") || looksLikeStructuredYAML(trimmed) {
 		schema, schemaErr := sshconfig.UnmarshalSchemaYAML(data)
 		if schemaErr == nil {
 			return schema, true, nil
@@ -73,4 +73,19 @@ func decodeLosslessInput(fileType string, data []byte) (sshconfig.Schema, bool, 
 	}
 
 	return sshconfig.Schema{}, false, nil
+}
+
+func looksLikeStructuredYAML(data []byte) bool {
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line == "---" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		lower := strings.ToLower(line)
+		return strings.HasPrefix(lower, "schemaversion:") ||
+			strings.HasPrefix(lower, "global:") ||
+			strings.HasPrefix(lower, "default:") ||
+			(strings.HasPrefix(lower, "group ") && strings.Contains(line, ":"))
+	}
+	return false
 }

--- a/main.go
+++ b/main.go
@@ -87,10 +87,14 @@ func Run(args Cmd.Args, deps Dependencies) error {
 		userInput = string(content)
 	}
 
-	fileType, err := Fn.DetectStringTypeStrict(userInput)
-	if err != nil {
-		deps.errorln("Error detecting config format:", err)
-		return err
+	fileType := Fn.DetectStringType(userInput)
+	if !args.Lossless {
+		var err error
+		fileType, err = Fn.DetectStringTypeStrict(userInput)
+		if err != nil {
+			deps.errorln("Error detecting config format:", err)
+			return err
+		}
 	}
 	result, err := deps.Process(fileType, userInput, args)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	Cmd "github.com/soulteary/ssh-config/v2/cmd"
+	Parser "github.com/soulteary/ssh-config/v2/internal/parser"
 )
 
 func TestRun(t *testing.T) {
@@ -235,6 +236,44 @@ func TestRunLosslessPipePreservesInputAndOutputBytes(t *testing.T) {
 	}
 	if !bytes.Equal(output, input) {
 		t.Fatalf("stdout = %q, want %q", output, input)
+	}
+}
+
+func TestRunLosslessReadsItsStructuredOutput(t *testing.T) {
+	original := []byte("Host=example\r\nIdentityFile first\r\nIdentityFile second")
+	formats := []struct {
+		name string
+		args Cmd.Args
+	}{
+		{name: "YAML", args: Cmd.Args{ToYAML: true, Lossless: true}},
+		{name: "JSON", args: Cmd.Args{ToJSON: true, Lossless: true}},
+	}
+
+	for _, format := range formats {
+		t.Run(format.name, func(t *testing.T) {
+			structured, err := Parser.Process("TEXT", string(original), format.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var output []byte
+			err = Run(Cmd.Args{ToSSH: true, Lossless: true}, Dependencies{
+				Println:               func(...interface{}) (int, error) { return 0, nil },
+				CheckUseStdin:         func() bool { return true },
+				GetLosslessStdin:      func() ([]byte, error) { return structured, nil },
+				GetUserInputFromStdin: func() string { t.Fatal("legacy stdin reader called"); return "" },
+				Process:               Parser.Process,
+				WriteOutput: func(data []byte) error {
+					output = append([]byte(nil), data...)
+					return nil
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(output, original) {
+				t.Fatalf("round trip mismatch\n got: %q\nwant: %q", output, original)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- bypass legacy strict format detection when `-lossless` is selected
- recognize v3 YAML envelopes and malformed legacy YAML before treating input as SSH text
- allow v3 JSON objects to reach the strict v3 decoder instead of rejecting them as non-array legacy JSON
- add end-to-end `Run` tests that export and re-import both v3 YAML and v3 JSON while preserving the original bytes

## Why

The documented CLI workflow could export v3 YAML/JSON but the top-level legacy detector rejected or misclassified those files before `ProcessLossless` saw them. The direct parser tests did not exercise that integration boundary.

## Verification

- `go test ./...`
- `go test -race ./...`
- `git diff --check`