### PR TITLE
fix: enforce lossless schema node invariants

### DIFF
--- a/pkg/sshconfig/schema.go
+++ b/pkg/sshconfig/schema.go
@@ -158,10 +158,35 @@ func (s Schema) Validate() error {
 			if node.Type != "directive" && node.Directive != nil {
 				return fmt.Errorf("sshconfig: document %d node %d of type %q has a directive", index, nodeIndex, node.Type)
 			}
-			if _, err := decodeSchemaRaw(node.RawBase64); err != nil {
+			raw, err := decodeSchemaRaw(node.RawBase64)
+			if err != nil {
+				return fmt.Errorf("sshconfig: document %d node %d: %w", index, nodeIndex, err)
+			}
+			if err := validateSchemaNodeRaw(node, raw); err != nil {
 				return fmt.Errorf("sshconfig: document %d node %d: %w", index, nodeIndex, err)
 			}
 		}
+	}
+	return nil
+}
+
+func validateSchemaNodeRaw(node SchemaNode, raw []byte) error {
+	if len(raw) == 0 {
+		if node.Type == "blank" || node.Type == "directive" && node.Directive != nil {
+			return nil
+		}
+		return fmt.Errorf("%s node has no raw bytes", node.Type)
+	}
+	doc, err := Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parse raw bytes: %w", err)
+	}
+	if len(doc.nodes) != 1 {
+		return fmt.Errorf("raw bytes contain %d physical lines; want exactly one", len(doc.nodes))
+	}
+	actual := schemaNodeType(doc.nodes[0].Kind)
+	if actual != node.Type {
+		return fmt.Errorf("raw bytes describe a %s node, not %s", actual, node.Type)
 	}
 	return nil
 }

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -2,6 +2,7 @@ package sshconfig
 
 import (
 	"bytes"
+	"encoding/base64"
 	"strings"
 	"testing"
 )
@@ -152,6 +153,33 @@ func TestSchemaNewDirectiveDefaultsToLF(t *testing.T) {
 	got, _ := doc.MarshalPreserve()
 	if want := []byte("Host example\n"); !bytes.Equal(got, want) {
 		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestSchemaValidationRejectsRawNodeShapeMismatches(t *testing.T) {
+	t.Parallel()
+	encode := func(raw string) string {
+		return base64.StdEncoding.EncodeToString([]byte(raw))
+	}
+	tests := []struct {
+		name string
+		node SchemaNode
+		want string
+	}{
+		{name: "declared comment", node: SchemaNode{Type: "comment", RawBase64: encode("Host example\n")}, want: "directive node, not comment"},
+		{name: "declared blank", node: SchemaNode{Type: "blank", RawBase64: encode("User root\n")}, want: "directive node, not blank"},
+		{name: "declared invalid", node: SchemaNode{Type: "invalid", RawBase64: encode("# comment\n")}, want: "comment node, not invalid"},
+		{name: "multiple lines", node: SchemaNode{Type: "comment", RawBase64: encode("# cover\nProxyCommand command\n")}, want: "2 physical lines"},
+		{name: "empty comment", node: SchemaNode{Type: "comment"}, want: "comment node has no raw bytes"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			schema := NewSchema(SchemaDocument{Nodes: []SchemaNode{test.node}})
+			err := schema.Validate()
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Validate() error = %v, want substring %q", err, test.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- parse every non-empty `rawBase64` value during schema validation
- require each schema node to contain exactly one physical source line
- require the declared node type to match the raw line's actual parsed type
- reject empty raw-only comment and invalid nodes
- preserve the documented exceptions for empty blank nodes and newly created directives

## Why

Previously a node declared as `comment`, `blank`, or `invalid` could carry one or more executable SSH directives in `rawBase64`. Reconstruction copied those bytes verbatim, violating the one-node/one-line schema contract and allowing semantic consumers to miss hidden configuration.

## Verification

- `go test ./...`
- `go test -race ./...`
- `git diff --check`