### PR TITLE
fix: reject cross-line directive edits

### DIFF
--- a/pkg/sshconfig/edit.go
+++ b/pkg/sshconfig/edit.go
@@ -13,8 +13,8 @@ func (d *Document) ReplaceDirective(id NodeID, keyword string, arguments ...stri
 	if d == nil {
 		return fmt.Errorf("sshconfig: nil document")
 	}
-	if keyword == "" {
-		return fmt.Errorf("sshconfig: directive keyword is empty")
+	if err := validateDirectiveInput(keyword, arguments, ""); err != nil {
+		return err
 	}
 	index := d.nodeIndex(id)
 	if index < 0 {
@@ -50,8 +50,8 @@ func (d *Document) InsertDirectiveAfter(after NodeID, keyword string, arguments 
 	if d == nil {
 		return 0, fmt.Errorf("sshconfig: nil document")
 	}
-	if keyword == "" {
-		return 0, fmt.Errorf("sshconfig: directive keyword is empty")
+	if err := validateDirectiveInput(keyword, arguments, ""); err != nil {
+		return 0, err
 	}
 	index := d.nodeIndex(after)
 	if index < 0 {
@@ -76,8 +76,8 @@ func (d *Document) AppendDirective(keyword string, arguments ...string) (NodeID,
 	if d == nil {
 		return 0, fmt.Errorf("sshconfig: nil document")
 	}
-	if keyword == "" {
-		return 0, fmt.Errorf("sshconfig: directive keyword is empty")
+	if err := validateDirectiveInput(keyword, arguments, ""); err != nil {
+		return 0, err
 	}
 	raw := d.renderNewDirective(keyword, arguments)
 	for i := len(d.nodes) - 1; i >= 0; i-- {
@@ -185,4 +185,24 @@ func syntheticDirective(keyword string, arguments []string) *Directive {
 		KeywordValue: strings.ToLower(keyword),
 		Arguments:    parsed,
 	}
+}
+
+func validateDirectiveInput(keyword string, arguments []string, comment string) error {
+	if keyword == "" {
+		return fmt.Errorf("sshconfig: directive keyword is empty")
+	}
+	for _, ch := range []byte(keyword) {
+		if ch <= ' ' || ch == 0x7f || ch == '=' || ch == '#' || ch == '\'' || ch == '"' {
+			return fmt.Errorf("sshconfig: directive keyword %q contains an invalid byte", keyword)
+		}
+	}
+	for index, argument := range arguments {
+		if strings.ContainsAny(argument, "\x00\r\n") {
+			return fmt.Errorf("sshconfig: directive argument %d contains NUL or a line ending", index)
+		}
+	}
+	if strings.ContainsAny(comment, "\x00\r\n") {
+		return fmt.Errorf("sshconfig: directive comment contains NUL or a line ending")
+	}
+	return nil
 }

--- a/pkg/sshconfig/schema.go
+++ b/pkg/sshconfig/schema.go
@@ -152,6 +152,11 @@ func (s Schema) Validate() error {
 			if node.Directive != nil && node.Directive.Keyword == "" {
 				return fmt.Errorf("sshconfig: document %d node %d has an empty keyword", index, nodeIndex)
 			}
+			if node.Directive != nil {
+				if err := validateDirectiveInput(node.Directive.Keyword, node.Directive.Arguments, node.Directive.Comment); err != nil {
+					return fmt.Errorf("sshconfig: document %d node %d: %w", index, nodeIndex, err)
+				}
+			}
 			if node.Type == "directive" && node.Directive == nil && node.RawBase64 == "" {
 				return fmt.Errorf("sshconfig: document %d node %d has no directive or raw bytes", index, nodeIndex)
 			}

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -208,6 +208,22 @@ func TestSchemaStrictValidation(t *testing.T) {
 	}
 }
 
+func TestSchemaRejectsCrossLineDirectiveFields(t *testing.T) {
+	t.Parallel()
+	tests := []SchemaDirective{
+		{Keyword: "Host\nProxyCommand", Arguments: []string{"example"}},
+		{Keyword: "Host", Arguments: []string{"example\rUser root"}},
+		{Keyword: "Host", Arguments: []string{"example"}, Comment: "# note\nProxyCommand command"},
+	}
+	for _, directive := range tests {
+		directive := directive
+		schema := NewSchema(SchemaDocument{Nodes: []SchemaNode{{Type: "directive", Directive: &directive}}})
+		if err := schema.Validate(); err == nil {
+			t.Fatalf("Validate() accepted cross-line directive: %+v", directive)
+		}
+	}
+}
+
 func TestMigrateLegacyFormats(t *testing.T) {
 	t.Parallel()
 	legacyYAML := []byte(`global:

--- a/pkg/sshconfig/writer_test.go
+++ b/pkg/sshconfig/writer_test.go
@@ -80,6 +80,26 @@ func TestEditErrors(t *testing.T) {
 	}
 }
 
+func TestDocumentEditsRejectCrossLineInput(t *testing.T) {
+	doc, _ := Parse([]byte("Host example\n"))
+	tests := []struct {
+		name string
+		edit func() error
+	}{
+		{name: "keyword newline", edit: func() error { return doc.ReplaceDirective(0, "Host\nProxyCommand", "example") }},
+		{name: "keyword comment", edit: func() error { return doc.ReplaceDirective(0, "#Host", "example") }},
+		{name: "argument newline", edit: func() error { return doc.ReplaceDirective(0, "Host", "safe\nProxyCommand command") }},
+		{name: "argument NUL", edit: func() error { _, err := doc.AppendDirective("Host", "safe\x00hidden"); return err }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.edit(); err == nil {
+				t.Fatal("edit accepted input that cannot fit in one physical directive")
+			}
+		})
+	}
+}
+
 func TestSaveAtomic(t *testing.T) {
 	t.Parallel()
 	directory := t.TempDir()


### PR DESCRIPTION
## Summary

- validate directive keywords before replace, insert, or append operations
- reject keyword bytes that change token or comment boundaries
- reject NUL, CR, and LF in directive arguments and comments
- apply the same validation to editable v3 schema directives
- add API and schema regression tests for cross-line configuration injection

## Why

Canonical quoting cannot represent a physical line ending inside one SSH directive. Previously an edited keyword, argument, or comment could introduce additional configuration lines while the document still modeled the edit as one node, violating the lossless editor contract.

## Verification

- `go test ./...`
- `go test -race ./...`
- `git diff --check`