### PR TITLE
fix: verify the opened Include file

### DIFF
--- a/pkg/sshconfig/include.go
+++ b/pkg/sshconfig/include.go
@@ -2,6 +2,7 @@ package sshconfig
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -90,12 +91,17 @@ func (g *DocumentGraph) resolveFile(path string, options ResolveOptions, depth i
 	if stack[path] {
 		return fmt.Errorf("sshconfig: recursive include cycle at %s", path)
 	}
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("sshconfig: read included file %s: %w", path, err)
+	}
+	defer file.Close()
 	if options.CheckPermissions {
-		if err := checkIncludePermissions(path); err != nil {
+		if err := checkIncludePermissions(file, path); err != nil {
 			return err
 		}
 	}
-	data, err := os.ReadFile(path)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return fmt.Errorf("sshconfig: read included file %s: %w", path, err)
 	}
@@ -208,8 +214,8 @@ func expandPercentTokens(value string, tokens map[byte]string) (string, error) {
 	return out.String(), nil
 }
 
-func checkIncludePermissions(path string) error {
-	info, err := os.Stat(path)
+func checkIncludePermissions(file *os.File, path string) error {
+	info, err := file.Stat()
 	if err != nil {
 		return fmt.Errorf("sshconfig: inspect included file %s: %w", path, err)
 	}
@@ -219,5 +225,5 @@ func checkIncludePermissions(path string) error {
 	if info.Mode().Perm()&0022 != 0 {
 		return fmt.Errorf("sshconfig: bad permissions on %s: mode %o is writable by group or others", path, info.Mode().Perm())
 	}
-	return nil
+	return checkIncludeOwner(info, path)
 }

--- a/pkg/sshconfig/include_owner_other.go
+++ b/pkg/sshconfig/include_owner_other.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+package sshconfig
+
+import "io/fs"
+
+// Non-Unix platforms do not expose OpenSSH's uid ownership model.
+func checkIncludeOwner(fs.FileInfo, string) error {
+	return nil
+}

--- a/pkg/sshconfig/include_owner_unix.go
+++ b/pkg/sshconfig/include_owner_unix.go
@@ -1,0 +1,22 @@
+//go:build unix
+
+package sshconfig
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"syscall"
+)
+
+func checkIncludeOwner(info fs.FileInfo, path string) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("sshconfig: inspect owner of included file %s", path)
+	}
+	uid := uint32(os.Getuid())
+	if stat.Uid != 0 && stat.Uid != uid {
+		return fmt.Errorf("sshconfig: bad owner on %s: uid %d is neither root nor current user %d", path, stat.Uid, uid)
+	}
+	return nil
+}

--- a/pkg/sshconfig/include_test.go
+++ b/pkg/sshconfig/include_test.go
@@ -120,6 +120,22 @@ func TestResolveIncludesPermissionCheck(t *testing.T) {
 	}
 }
 
+func TestResolveIncludesPermissionCheckReadsTheOpenedFile(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	entry := filepath.Join(directory, "config")
+	writeTestConfig(t, entry, "Host example\n")
+
+	file, err := os.Open(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if err := checkIncludePermissions(file, entry); err != nil {
+		t.Fatalf("checkIncludePermissions() error = %v", err)
+	}
+}
+
 func TestResolveIncludesExpansionErrors(t *testing.T) {
 	t.Parallel()
 	directory := t.TempDir()


### PR DESCRIPTION
## Summary

- open each Include target once and read from that same file descriptor
- perform regular-file, mode, and ownership checks with `File.Stat` before reading
- reject Unix Include files not owned by root or the current user, matching OpenSSH's ownership rule
- keep non-Unix builds portable where uid ownership semantics are unavailable
- retain lexical ordering, cycle detection, and existing expansion behavior
- add native and Windows cross-build coverage

## Why

The previous `os.Stat` followed by `os.ReadFile` sequence checked one path object and then reopened it, leaving a check/use race. It also accepted a safely-mode'd file owned by an unrelated account. OpenSSH validates the descriptor it actually reads.

## Verification

- `go test ./...`
- `go test -race ./...`
- `GOOS=windows GOARCH=amd64 go test -exec=true ./pkg/sshconfig`
- `git diff --check`