### PR TITLE
fix: reject special Include files without blocking

### DIFF
--- a/pkg/sshconfig/include.go
+++ b/pkg/sshconfig/include.go
@@ -91,7 +91,7 @@ func (g *DocumentGraph) resolveFile(path string, options ResolveOptions, depth i
 	if stack[path] {
 		return fmt.Errorf("sshconfig: recursive include cycle at %s", path)
 	}
-	file, err := os.Open(path)
+	file, err := openIncludeFile(path)
 	if err != nil {
 		return fmt.Errorf("sshconfig: read included file %s: %w", path, err)
 	}
@@ -222,8 +222,5 @@ func checkIncludePermissions(file *os.File, path string) error {
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("sshconfig: included path %s is not a regular file", path)
 	}
-	if info.Mode().Perm()&0022 != 0 {
-		return fmt.Errorf("sshconfig: bad permissions on %s: mode %o is writable by group or others", path, info.Mode().Perm())
-	}
-	return checkIncludeOwner(info, path)
+	return checkIncludePlatformPermissions(info, path)
 }

--- a/pkg/sshconfig/include_owner_other.go
+++ b/pkg/sshconfig/include_owner_other.go
@@ -2,9 +2,16 @@
 
 package sshconfig
 
-import "io/fs"
+import (
+	"io/fs"
+	"os"
+)
 
-// Non-Unix platforms do not expose OpenSSH's uid ownership model.
-func checkIncludeOwner(fs.FileInfo, string) error {
+func openIncludeFile(path string) (*os.File, error) {
+	return os.Open(path)
+}
+
+// Non-Unix platforms do not expose OpenSSH's uid ownership and mode model.
+func checkIncludePlatformPermissions(fs.FileInfo, string) error {
 	return nil
 }

--- a/pkg/sshconfig/include_owner_unix.go
+++ b/pkg/sshconfig/include_owner_unix.go
@@ -9,7 +9,14 @@ import (
 	"syscall"
 )
 
-func checkIncludeOwner(info fs.FileInfo, path string) error {
+func openIncludeFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+}
+
+func checkIncludePlatformPermissions(info fs.FileInfo, path string) error {
+	if info.Mode().Perm()&0022 != 0 {
+		return fmt.Errorf("sshconfig: bad permissions on %s: mode %o is writable by group or others", path, info.Mode().Perm())
+	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
 		return fmt.Errorf("sshconfig: inspect owner of included file %s", path)

--- a/pkg/sshconfig/include_unix_test.go
+++ b/pkg/sshconfig/include_unix_test.go
@@ -1,0 +1,34 @@
+//go:build unix
+
+package sshconfig
+
+import (
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestResolveIncludesRejectsFIFOWithoutBlocking(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "config.fifo")
+	if err := syscall.Mkfifo(path, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := ResolveIncludes(path, ResolveOptions{CheckPermissions: true})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+			t.Fatalf("FIFO error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ResolveIncludes blocked while opening a FIFO")
+	}
+}


### PR DESCRIPTION
## Summary

- open Include targets non-blockingly on Unix before validating the same file descriptor
- keep regular-file, mode, and owner checks on Unix while avoiding Unix permission semantics elsewhere
- add a regression test proving an unread FIFO is rejected instead of hanging

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- Windows amd64 test-binary cross-build

Follow-up to #30 and its post-merge review feedback.