### PR TITLE
fix: preserve directory scan boundaries

### DIFF
--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -194,6 +194,9 @@ func GetPathContent(src string) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("no valid SSH config found in %s: %w", src, err)
 		}
+		if len(content) > 0 && content[len(content)-1] != '\n' && content[len(content)-1] != '\r' {
+			content = append(content, '\n')
+		}
 		content = append(content, fileContent...)
 	}
 	return content, nil

--- a/internal/fn/fn_test.go
+++ b/internal/fn/fn_test.go
@@ -510,9 +510,8 @@ func TestGetPathContent(t *testing.T) {
 	if err != nil {
 		t.Errorf("GetPathContent failed for directory: %v", err)
 	}
-	expectedContent := append(content1, content2...)
-	expectedContent2 := append(content1, content2...)
-	if !reflect.DeepEqual(content, expectedContent) || !reflect.DeepEqual(content, expectedContent2) {
+	expectedContent := []byte("Host test1\nHost test2")
+	if !reflect.DeepEqual(content, expectedContent) {
 		t.Errorf("Expected %s, got %s", expectedContent, content)
 	}
 
@@ -592,6 +591,26 @@ func TestGetPathContent(t *testing.T) {
 	_, err = Fn.GetPathContent(dirWithCorruptFile)
 	if err == nil {
 		t.Fatalf("Expected error for directory with corrupt file, got nil")
+	}
+}
+
+func TestGetPathContentSeparatesFilesWithoutFinalNewline(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	first := filepath.Join(directory, "10-first")
+	second := filepath.Join(directory, "20-second")
+	if err := os.WriteFile(first, []byte("Host first"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, []byte("Host second\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Fn.GetPathContent(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "Host first\nHost second\n" {
+		t.Fatalf("GetPathContent() = %q", got)
 	}
 }
 

--- a/internal/fn/scanner.go
+++ b/internal/fn/scanner.go
@@ -24,7 +24,10 @@ import (
 	"strings"
 
 	"github.com/soulteary/ssh-config/v2/internal/define"
+	"github.com/soulteary/ssh-config/v2/pkg/sshconfig"
 )
+
+const maxScannedConfigLine = 1024 * 1024
 
 type ConfigFile struct {
 	Path    string
@@ -57,29 +60,24 @@ func IsConfigFile(path string) bool {
 	defer file.Close()
 
 	scanner := bufio.NewScanner(file)
-	lineCount := 0
-	validLines := 0
-
-	// check first 5 lines
-	for scanner.Scan() && lineCount < 5 {
+	scanner.Buffer(make([]byte, 64*1024), maxScannedConfigLine)
+	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		lineCount++
-
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-
-		parts := strings.Fields(line)
-		if len(parts) >= 2 {
-			key := strings.ToLower(parts[0])
-			switch key {
-			case "host", "hostname", "user", "port", "identityfile", "proxycommand":
-				validLines++
+		doc, err := sshconfig.Parse([]byte(line))
+		if err != nil {
+			continue
+		}
+		nodes := doc.Nodes()
+		if len(nodes) == 1 && nodes[0].Directive != nil {
+			if _, known := sshconfig.LookupKeyword(nodes[0].Directive.KeywordValue); known {
+				return true
 			}
 		}
 	}
-
-	return validLines > 0
+	return false
 }
 
 func ReadSSHConfigs(sshPath string) (*SSHConfig, error) {
@@ -117,6 +115,9 @@ func ReadSSHConfigs(sshPath string) (*SSHConfig, error) {
 			if !isDirReadable(info) {
 				return fmt.Errorf("directory %s is not accessible", path)
 			}
+			return nil
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
 			return nil
 		}
 
@@ -159,6 +160,7 @@ func ReadSingleConfig(path string) *ConfigFile {
 	}
 
 	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), maxScannedConfigLine)
 	var currentHost string
 	var content []string
 

--- a/internal/fn/scanner_internal_test.go
+++ b/internal/fn/scanner_internal_test.go
@@ -1,7 +1,6 @@
 package fn
 
 import (
-	"bufio"
 	"os"
 	"strings"
 	"testing"
@@ -14,7 +13,7 @@ func TestReadSingleConfigScannerErrorInternal(t *testing.T) {
 	}
 	defer os.Remove(tmpfile.Name())
 
-	longLine := strings.Repeat("a", bufio.MaxScanTokenSize*2)
+	longLine := strings.Repeat("a", maxScannedConfigLine+1)
 	content := "Host testhost\n" + longLine
 
 	if _, err := tmpfile.WriteString(content); err != nil {

--- a/internal/fn/scanner_test.go
+++ b/internal/fn/scanner_test.go
@@ -17,7 +17,6 @@
 package fn_test
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -534,6 +533,19 @@ Nothing to see here`,
 	}
 }
 
+func TestIsConfigFileRecognizesCommentsAndInclude(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	path := filepath.Join(directory, "config")
+	content := strings.Repeat("# explanatory header\n", 12) + "Include config.d/*\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if !fn.IsConfigFile(path) {
+		t.Fatal("IsConfigFile() rejected a valid Include-only config after a long comment header")
+	}
+}
+
 // TestReadSingleConfig_ScannerError tests the scanner error handling
 func TestReadSingleConfig_ScannerError(t *testing.T) {
 	// 创建一个包含无效数据的文件
@@ -544,7 +556,7 @@ func TestReadSingleConfig_ScannerError(t *testing.T) {
 	defer os.Remove(tmpfile.Name())
 
 	// 写入一些正常数据和一个超长行来触发 scanner 错误
-	longLine := strings.Repeat("a", bufio.MaxScanTokenSize*2)
+	longLine := strings.Repeat("a", 1024*1024+1)
 	content := "Host testhost\n" + longLine
 
 	if _, err := tmpfile.WriteString(content); err != nil {


### PR DESCRIPTION
## Summary

- recognize valid SSH configuration files by parsing known OpenSSH directives instead of inspecting only six keywords in the first five lines
- ignore symlinks while walking configuration directories and support lines up to 1 MiB consistently
- insert a line boundary when concatenating files whose previous file lacks a final newline
- keep the over-limit scanner failure path covered

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`