### PR TITLE
fix: isolate document node snapshots

### DIFF
--- a/pkg/sshconfig/document.go
+++ b/pkg/sshconfig/document.go
@@ -101,13 +101,35 @@ func (d *Document) Bytes() []byte {
 	return bytes.Clone(d.source)
 }
 
-// Nodes returns a shallow copy of the document nodes. Syntax slices inside a
-// directive must be treated as immutable.
+// Nodes returns an independent copy of the document nodes.
 func (d *Document) Nodes() []Node {
 	if d == nil {
 		return nil
 	}
-	return append([]Node(nil), d.nodes...)
+	nodes := make([]Node, len(d.nodes))
+	for index, node := range d.nodes {
+		nodes[index] = cloneNode(node)
+	}
+	return nodes
+}
+
+func cloneNode(node Node) Node {
+	node.Directive = cloneDirective(node.Directive)
+	node.original = cloneDirective(node.original)
+	return node
+}
+
+func cloneDirective(directive *Directive) *Directive {
+	if directive == nil {
+		return nil
+	}
+	clone := *directive
+	clone.Arguments = append([]Argument(nil), directive.Arguments...)
+	if directive.Comment != nil {
+		comment := *directive.Comment
+		clone.Comment = &comment
+	}
+	return &clone
 }
 
 // Diagnostics returns a copy of recoverable parse diagnostics.

--- a/pkg/sshconfig/parser_test.go
+++ b/pkg/sshconfig/parser_test.go
@@ -70,6 +70,36 @@ func TestParseDirectiveSyntax(t *testing.T) {
 	}
 }
 
+func TestNodesReturnsIndependentSyntax(t *testing.T) {
+	t.Parallel()
+	doc, err := Parse([]byte("Host example # comment\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nodes := doc.Nodes()
+	nodes[0].Kind = NodeInvalid
+	nodes[0].Directive.KeywordValue = "match"
+	nodes[0].Directive.Arguments[0].Value = "changed"
+	nodes[0].Directive.Arguments = append(nodes[0].Directive.Arguments, Argument{Value: "extra"})
+	nodes[0].Directive.Comment.Span = Span{}
+
+	fresh := doc.Nodes()
+	if fresh[0].Kind != NodeDirective {
+		t.Fatalf("node kind = %v, want NodeDirective", fresh[0].Kind)
+	}
+	directive := fresh[0].Directive
+	if directive.KeywordValue != "host" || len(directive.Arguments) != 1 || directive.Arguments[0].Value != "example" {
+		t.Fatalf("directive was mutated through Nodes(): %#v", directive)
+	}
+	if got := string(doc.Raw(directive.Comment.Span)); got != "# comment" {
+		t.Fatalf("comment = %q, want %q", got, "# comment")
+	}
+	if got := string(doc.Bytes()); got != "Host example # comment\n" {
+		t.Fatalf("document bytes = %q", got)
+	}
+}
+
 func TestMalformedQuoteIsRetainedAndDiagnosed(t *testing.T) {
 	t.Parallel()
 	input := []byte("Host \"unfinished\n")


### PR DESCRIPTION
## Summary

- make `Document.Nodes()` return fully independent node and directive snapshots
- clone directive argument slices and inline-comment tokens instead of exposing internal mutable references
- add a regression test that mutates every exported nested value and verifies the document remains unchanged

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`