### PR TITLE
fix: reject ambiguous legacy documents

### DIFF
--- a/internal/fn/decode_strict_test.go
+++ b/internal/fn/decode_strict_test.go
@@ -1,0 +1,53 @@
+package fn_test
+
+import (
+	"testing"
+
+	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
+)
+
+func TestGetYamlDataStrictRejectsUnknownAndDuplicateFields(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"unknown group field": "group work:\n  Prefx: work-\n",
+		"unknown host field":  "group work:\n  Hosts:\n    example:\n      Nmae: example\n",
+		"duplicate field":     "group work:\n  Prefix: one\n  Prefix: two\n",
+	}
+	for name, input := range tests {
+		name, input := name, input
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := Fn.GetYamlDataStrict(input); err == nil {
+				t.Fatal("GetYamlDataStrict() accepted an ambiguous legacy document")
+			}
+		})
+	}
+}
+
+func TestGetJSONDataStrictRejectsUnknownAndTrailingValues(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"unknown field":  `[{"Name":"example","Datta":{"User":"alice"}}]`,
+		"second value":   `[] []`,
+		"trailing token": `[] invalid`,
+	}
+	for name, input := range tests {
+		name, input := name, input
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := Fn.GetJSONDataStrict(input); err == nil {
+				t.Fatal("GetJSONDataStrict() accepted an ambiguous legacy document")
+			}
+		})
+	}
+}
+
+func TestStrictLegacyDecodersKeepValidInput(t *testing.T) {
+	t.Parallel()
+	if _, err := Fn.GetYamlDataStrict("group work:\n  Prefix: work-\n"); err != nil {
+		t.Fatalf("GetYamlDataStrict() error = %v", err)
+	}
+	if _, err := Fn.GetJSONDataStrict("  [{\"Name\":\"example\",\"Data\":{\"User\":\"alice\"}}]\n"); err != nil {
+		t.Fatalf("GetJSONDataStrict() error = %v", err)
+	}
+}

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -85,7 +86,7 @@ func GetYamlData(input string) (yamlConfig Define.YAMLOutput) {
 // GetYamlDataStrict decodes the legacy YAML format without hiding syntax or
 // type errors from callers that must avoid destructive conversions.
 func GetYamlDataStrict(input string) (yamlConfig Define.YAMLOutput, err error) {
-	err = yaml.Unmarshal([]byte(input), &yamlConfig)
+	err = yaml.UnmarshalStrict([]byte(input), &yamlConfig)
 	return yamlConfig, err
 }
 
@@ -106,10 +107,24 @@ func GetJSONData(input string) (jsonConfig []Define.HostConfigForJSON) {
 	return jsonConfig
 }
 
-// GetJSONDataStrict decodes the legacy JSON format without hiding errors.
+// GetJSONDataStrict decodes exactly one legacy JSON document and rejects
+// unknown fields.
 func GetJSONDataStrict(input string) (jsonConfig []Define.HostConfigForJSON, err error) {
-	err = json.Unmarshal([]byte(input), &jsonConfig)
-	return jsonConfig, err
+	decoder := json.NewDecoder(strings.NewReader(input))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&jsonConfig); err != nil {
+		return jsonConfig, err
+	}
+
+	var trailing json.RawMessage
+	switch err := decoder.Decode(&trailing); err {
+	case io.EOF:
+		return jsonConfig, nil
+	case nil:
+		return jsonConfig, fmt.Errorf("unexpected JSON value after document")
+	default:
+		return jsonConfig, fmt.Errorf("invalid trailing JSON data: %w", err)
+	}
 }
 
 func DetectStringType(input string) string {


### PR DESCRIPTION
## Summary

- use YAML strict decoding so misspelled and duplicate nested fields cannot be silently ignored
- disallow unknown JSON object fields
- require JSON input to contain exactly one document, rejecting extra values and trailing tokens
- retain valid legacy YAML and JSON behavior with positive coverage

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`