### PR TITLE
fix: skip Include-only directory entries

### DIFF
--- a/internal/fn/fn_test.go
+++ b/internal/fn/fn_test.go
@@ -614,6 +614,30 @@ func TestGetPathContentSeparatesFilesWithoutFinalNewline(t *testing.T) {
 	}
 }
 
+func TestGetPathContentSkipsIncludeOnlyEntry(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	fragmentDirectory := filepath.Join(directory, "config.d")
+	if err := os.Mkdir(fragmentDirectory, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(directory, "config"), []byte("Include config.d/*\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	fragment := []byte("Host work\n  User alice\n")
+	if err := os.WriteFile(filepath.Join(fragmentDirectory, "work"), fragment, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := Fn.GetPathContent(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(content, fragment) {
+		t.Fatalf("GetPathContent() = %q, want only the included fragment %q", content, fragment)
+	}
+}
+
 func TestSave(t *testing.T) {
 	testDir := filepath.Join(os.TempDir(), "test_save")
 	defer os.RemoveAll(testDir)

--- a/internal/fn/scanner.go
+++ b/internal/fn/scanner.go
@@ -52,7 +52,16 @@ func IsExcluded(filename string) bool {
 }
 
 func IsConfigFile(path string) bool {
-	// read file first few lines to determine if it's SSH config file format
+	return hasConfigDirective(path, func(string) bool { return true })
+}
+
+func isLegacyDirectoryConfigFile(path string) bool {
+	return hasConfigDirective(path, func(keyword string) bool {
+		return keyword != "include"
+	})
+}
+
+func hasConfigDirective(path string, accept func(string) bool) bool {
 	file, err := os.Open(path)
 	if err != nil {
 		return false
@@ -72,7 +81,8 @@ func IsConfigFile(path string) bool {
 		}
 		nodes := doc.Nodes()
 		if len(nodes) == 1 && nodes[0].Directive != nil {
-			if _, known := sshconfig.LookupKeyword(nodes[0].Directive.KeywordValue); known {
+			keyword := nodes[0].Directive.KeywordValue
+			if _, known := sshconfig.LookupKeyword(keyword); known && accept(keyword) {
 				return true
 			}
 		}
@@ -125,7 +135,7 @@ func ReadSSHConfigs(sshPath string) (*SSHConfig, error) {
 			return nil
 		}
 
-		if !IsConfigFile(path) {
+		if !isLegacyDirectoryConfigFile(path) {
 			return nil
 		}
 


### PR DESCRIPTION
## Summary

- keep `IsConfigFile` able to recognize Include-only SSH files
- exclude Include-only entry files specifically from legacy directory aggregation
- continue recursively discovering and converting the actual Host fragments
- add an end-to-end directory regression test for the common `config` + `config.d/*` layout

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

Follow-up to the post-merge P1 review on #32.