### PR TITLE
fix: preserve empty argument slices in node snapshots

### DIFF
--- a/pkg/sshconfig/document.go
+++ b/pkg/sshconfig/document.go
@@ -124,7 +124,9 @@ func cloneDirective(directive *Directive) *Directive {
 		return nil
 	}
 	clone := *directive
-	clone.Arguments = append([]Argument(nil), directive.Arguments...)
+	if directive.Arguments != nil {
+		clone.Arguments = append([]Argument{}, directive.Arguments...)
+	}
 	if directive.Comment != nil {
 		comment := *directive.Comment
 		clone.Comment = &comment

--- a/pkg/sshconfig/parser_test.go
+++ b/pkg/sshconfig/parser_test.go
@@ -100,6 +100,20 @@ func TestNodesReturnsIndependentSyntax(t *testing.T) {
 	}
 }
 
+func TestNodesPreservesNonNilEmptyArguments(t *testing.T) {
+	t.Parallel()
+	doc, err := Parse(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := doc.AppendDirective("Host"); err != nil {
+		t.Fatal(err)
+	}
+	if arguments := doc.Nodes()[0].Directive.Arguments; arguments == nil || len(arguments) != 0 {
+		t.Fatalf("Arguments = %#v, want a non-nil empty slice", arguments)
+	}
+}
+
 func TestMalformedQuoteIsRetainedAndDiagnosed(t *testing.T) {
 	t.Parallel()
 	input := []byte("Host \"unfinished\n")


### PR DESCRIPTION
## Summary

- preserve the nilness of directive argument slices while deep-copying document nodes
- keep synthetic directives with zero arguments represented as a non-nil empty slice
- add a regression test for the observable snapshot contract

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

Follow-up to the post-merge review on #33.