### PR TITLE
fix: preserve YAML merge overrides

### DIFF
--- a/internal/fn/decode_strict_test.go
+++ b/internal/fn/decode_strict_test.go
@@ -9,9 +9,10 @@ import (
 func TestGetYamlDataStrictRejectsUnknownAndDuplicateFields(t *testing.T) {
 	t.Parallel()
 	tests := map[string]string{
-		"unknown group field": "group work:\n  Prefx: work-\n",
-		"unknown host field":  "group work:\n  Hosts:\n    example:\n      Nmae: example\n",
-		"duplicate field":     "group work:\n  Prefix: one\n  Prefix: two\n",
+		"unknown group field":        "group work:\n  Prefx: work-\n",
+		"unknown merged group field": "group work:\n  <<: &defaults\n    Prefx: work-\n  Prefix: safe-\n",
+		"unknown host field":         "group work:\n  Hosts:\n    example:\n      Nmae: example\n",
+		"duplicate field":            "group work:\n  Prefix: one\n  Prefix: two\n",
 	}
 	for name, input := range tests {
 		name, input := name, input
@@ -44,8 +45,16 @@ func TestGetJSONDataStrictRejectsUnknownAndTrailingValues(t *testing.T) {
 
 func TestStrictLegacyDecodersKeepValidInput(t *testing.T) {
 	t.Parallel()
-	if _, err := Fn.GetYamlDataStrict("group work:\n  Prefix: work-\n"); err != nil {
+	yamlInput := "global:\n  <<: &defaults\n    User: alice\n    Port: \"22\"\n  User: bob\ngroup work:\n  Prefix: work-\n  Hosts:\n    example:\n      Extra:\n        prefix: host-\n"
+	yamlConfig, err := Fn.GetYamlDataStrict(yamlInput)
+	if err != nil {
 		t.Fatalf("GetYamlDataStrict() error = %v", err)
+	}
+	if yamlConfig.Global["User"] != "bob" || yamlConfig.Global["Port"] != "22" {
+		t.Fatalf("YAML merge override = %#v", yamlConfig.Global)
+	}
+	if prefix := yamlConfig.Groups["group work"].Hosts["example"].Extra.Prefix; prefix != "host-" {
+		t.Fatalf("host prefix = %q, want host-", prefix)
 	}
 	if _, err := Fn.GetJSONDataStrict("  [{\"Name\":\"example\",\"Data\":{\"User\":\"alice\"}}]\n"); err != nil {
 		t.Fatalf("GetJSONDataStrict() error = %v", err)

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -86,7 +86,11 @@ func GetYamlData(input string) (yamlConfig Define.YAMLOutput) {
 // GetYamlDataStrict decodes the legacy YAML format without hiding syntax or
 // type errors from callers that must avoid destructive conversions.
 func GetYamlDataStrict(input string) (yamlConfig Define.YAMLOutput, err error) {
-	err = yaml.UnmarshalStrict([]byte(input), &yamlConfig)
+	data := []byte(input)
+	if err := validateLegacyYAML(data); err != nil {
+		return yamlConfig, err
+	}
+	err = yaml.Unmarshal(data, &yamlConfig)
 	return yamlConfig, err
 }
 

--- a/internal/fn/yaml_strict.go
+++ b/internal/fn/yaml_strict.go
@@ -1,0 +1,165 @@
+package fn
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+)
+
+type yamlEntry struct {
+	key   string
+	value any
+}
+
+func validateLegacyYAML(data []byte) error {
+	var ordered yaml.MapSlice
+	if err := yaml.Unmarshal(data, &ordered); err != nil {
+		return err
+	}
+	if err := validateYAMLRoot(ordered); err != nil {
+		return err
+	}
+
+	// MapSlice retains explicit duplicates, but yaml.v2 omits values inherited
+	// through merge keys from it. Validate the resolved map as a second pass so
+	// merged unknown fields are checked without rejecting valid overrides.
+	var resolved map[interface{}]interface{}
+	if err := yaml.Unmarshal(data, &resolved); err != nil {
+		return err
+	}
+	return validateYAMLRoot(resolved)
+}
+
+func validateYAMLRoot(value any) error {
+	entries, err := yamlMappingEntries(value, "document")
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		switch entry.key {
+		case "global", "default":
+			if err := validateYAMLStringMap(entry.value, entry.key); err != nil {
+				return err
+			}
+		default:
+			if err := validateYAMLGroup(entry.value, entry.key); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateYAMLGroup(value any, path string) error {
+	entries, err := yamlMappingEntries(value, path)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		switch entry.key {
+		case "Prefix":
+		case "Common":
+			if err := validateYAMLStringMap(entry.value, path+".Common"); err != nil {
+				return err
+			}
+		case "Hosts":
+			if err := validateYAMLHosts(entry.value, path+".Hosts"); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown YAML field %q in %s", entry.key, path)
+		}
+	}
+	return nil
+}
+
+func validateYAMLHosts(value any, path string) error {
+	entries, err := yamlMappingEntries(value, path)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if err := validateYAMLHost(entry.value, path+"."+entry.key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateYAMLHost(value any, path string) error {
+	entries, err := yamlMappingEntries(value, path)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		switch entry.key {
+		case "Name", "Notes":
+		case "config":
+			if err := validateYAMLStringMap(entry.value, path+".config"); err != nil {
+				return err
+			}
+		case "Extra":
+			if err := validateYAMLExtra(entry.value, path+".Extra"); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown YAML field %q in %s", entry.key, path)
+		}
+	}
+	return nil
+}
+
+func validateYAMLExtra(value any, path string) error {
+	entries, err := yamlMappingEntries(value, path)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.key != "prefix" {
+			return fmt.Errorf("unknown YAML field %q in %s", entry.key, path)
+		}
+	}
+	return nil
+}
+
+func validateYAMLStringMap(value any, path string) error {
+	_, err := yamlMappingEntries(value, path)
+	return err
+}
+
+func yamlMappingEntries(value any, path string) ([]yamlEntry, error) {
+	var entries []yamlEntry
+	switch mapping := value.(type) {
+	case nil:
+		return nil, nil
+	case yaml.MapSlice:
+		entries = make([]yamlEntry, 0, len(mapping))
+		for _, item := range mapping {
+			key, ok := item.Key.(string)
+			if !ok {
+				return nil, fmt.Errorf("non-string YAML field in %s", path)
+			}
+			entries = append(entries, yamlEntry{key: key, value: item.Value})
+		}
+	case map[interface{}]interface{}:
+		entries = make([]yamlEntry, 0, len(mapping))
+		for rawKey, item := range mapping {
+			key, ok := rawKey.(string)
+			if !ok {
+				return nil, fmt.Errorf("non-string YAML field in %s", path)
+			}
+			entries = append(entries, yamlEntry{key: key, value: item})
+		}
+	default:
+		return nil, nil // The typed unmarshal reports the more useful type error.
+	}
+
+	seen := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if _, exists := seen[entry.key]; exists {
+			return nil, fmt.Errorf("duplicate YAML field %q in %s", entry.key, path)
+		}
+		seen[entry.key] = struct{}{}
+	}
+	return entries, nil
+}


### PR DESCRIPTION
## Summary

- preserve valid YAML merge-key semantics where explicit fields override inherited values
- retain strict rejection of explicit duplicate fields and unknown schema fields
- validate both ordered source mappings and resolved merge mappings so inherited unknown fields cannot bypass checks
- add coverage for valid overrides and invalid fields inherited through a merge

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

Follow-up to the post-merge review on #35.