### PR TITLE
fix: detect reordered v3 YAML

### DIFF
--- a/internal/parser/lossless.go
+++ b/internal/parser/lossless.go
@@ -82,10 +82,13 @@ func looksLikeStructuredYAML(data []byte) bool {
 			continue
 		}
 		lower := strings.ToLower(line)
-		return strings.HasPrefix(lower, "schemaversion:") ||
+		if strings.HasPrefix(lower, "schemaversion:") ||
+			strings.HasPrefix(lower, "documents:") ||
 			strings.HasPrefix(lower, "global:") ||
 			strings.HasPrefix(lower, "default:") ||
-			(strings.HasPrefix(lower, "group ") && strings.Contains(line, ":"))
+			(strings.HasPrefix(lower, "group ") && strings.Contains(line, ":")) {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/parser/lossless_test.go
+++ b/internal/parser/lossless_test.go
@@ -60,3 +60,24 @@ func TestProcessLosslessRejectsInvalidStructuredInput(t *testing.T) {
 		t.Fatal("invalid structured input was accepted")
 	}
 }
+
+func TestProcessLosslessDetectsReorderedV3YAML(t *testing.T) {
+	t.Parallel()
+	input := `documents:
+- path: ""
+  nodes:
+  - type: directive
+    directive:
+      keyword: Host
+      arguments:
+      - example
+schemaVersion: 3
+`
+	got, err := Parser.Process("TEXT", input, Cmd.Args{ToSSH: true, Lossless: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "Host example\n" {
+		t.Fatalf("reordered v3 YAML output = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- scan all meaningful YAML lines instead of only the first key
- recognize `documents:` as a v3 schema marker
- add a regression test for v3 YAML with `documents` before `schemaVersion`

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`