### PR TITLE
fix: preserve legacy SSH arguments

### DIFF
--- a/internal/parser/legacy_safety_test.go
+++ b/internal/parser/legacy_safety_test.go
@@ -60,3 +60,26 @@ func TestGroupSSHConfigAcceptsRepresentableLegacyInput(t *testing.T) {
 		t.Fatalf("GroupSSHConfig() = %#v", configs)
 	}
 }
+
+func TestLegacyConversionPreservesQuotedAndHashArguments(t *testing.T) {
+	t.Parallel()
+
+	configs, err := Parser.GroupSSHConfig("Host example\n  IdentityFile \"/tmp/key with space\"\n  ControlPath /tmp/socket#one\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(Parser.ConvertToSSH(configs))
+	for _, want := range []string{`IdentityFile "/tmp/key with space"`, `ControlPath "/tmp/socket#one"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("ConvertToSSH() = %q, missing %q", got, want)
+		}
+	}
+
+	reparsed, err := Parser.GroupSSHConfig(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reparsed[0].Config["IdentityFile"] != "/tmp/key with space" || reparsed[0].Config["ControlPath"] != "/tmp/socket#one" {
+		t.Fatalf("round trip = %#v", reparsed[0].Config)
+	}
+}

--- a/internal/parser/ssh.go
+++ b/internal/parser/ssh.go
@@ -360,11 +360,11 @@ func ConvertToSSH(hostConfigs []Define.HostConfig) []byte {
 					lines = append(lines, fmt.Sprintf("# %s", note))
 				}
 			}
-			lines = append(lines, fmt.Sprintf("Host %s", config.Name))
+			lines = append(lines, fmt.Sprintf("Host %s", renderLegacyHostPatterns(config.Name)))
 
 			orderMaps := Fn.GetOrderMaps(config.Config)
 			for _, field := range orderMaps.Keys {
-				lines = append(lines, fmt.Sprintf("    %s %s", field, orderMaps.Data[field]))
+				lines = append(lines, fmt.Sprintf("    %s %s", field, renderLegacyDirectiveValue(field, orderMaps.Data[field])))
 			}
 		}
 		lines = append(lines, "")
@@ -381,14 +381,34 @@ func ConvertToSSH(hostConfigs []Define.HostConfig) []byte {
 			}
 
 			hostName := fmt.Sprintf("%s%s", config.Extra.Prefix, config.Name)
-			lines = append(lines, fmt.Sprintf("Host %s", hostName))
+			lines = append(lines, fmt.Sprintf("Host %s", renderLegacyHostPatterns(hostName)))
 			orderMaps := Fn.GetOrderMaps(config.Config)
 			for _, field := range orderMaps.Keys {
-				lines = append(lines, fmt.Sprintf("    %s %s", field, orderMaps.Data[field]))
+				lines = append(lines, fmt.Sprintf("    %s %s", field, renderLegacyDirectiveValue(field, orderMaps.Data[field])))
 			}
 			lines = append(lines, "")
 		}
 		lines = append(lines, "")
 	}
 	return []byte(strings.Join(lines, "\n"))
+}
+
+func renderLegacyHostPatterns(value string) string {
+	patterns := strings.Fields(value)
+	if len(patterns) == 0 {
+		return sshconfig.QuoteArgument(value)
+	}
+	for index, pattern := range patterns {
+		patterns[index] = sshconfig.QuoteArgument(pattern)
+	}
+	return strings.Join(patterns, " ")
+}
+
+func renderLegacyDirectiveValue(keyword, value string) string {
+	// ProxyCommand is a shell command represented by the entire remainder of
+	// the line. Quoting it as one SSH argument changes the command executed.
+	if strings.EqualFold(keyword, "ProxyCommand") {
+		return value
+	}
+	return sshconfig.QuoteArgument(value)
 }

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -16,7 +16,7 @@
 
 // Package lexer tokenizes SSH client configuration files.
 // Format follows OpenSSH ssh_config(5): https://man7.org/linux/man-pages/man5/ssh_config.5.html
-// - Comments: # to end of line; empty lines ignored.
+// - Comments: # at a token boundary to end of line; empty lines ignored.
 // - Keywords (Host, Match, Include) are case-insensitive; arguments are case-sensitive.
 // - Options separated by whitespace or optional whitespace and exactly one '='.
 // - Arguments containing spaces may be enclosed in double quotes; \" and \\ are escaped.
@@ -198,7 +198,7 @@ func (l *Lexer) NextToken() (Token, error) {
 			return l.emit(TokenEquals, "="), nil
 
 		default:
-			for l.peek() != 0 && l.peek() != '\n' && l.peek() != ' ' && l.peek() != '\t' && l.peek() != '\r' && l.peek() != '#' && l.peek() != '=' {
+			for l.peek() != 0 && l.peek() != '\n' && l.peek() != ' ' && l.peek() != '\t' && l.peek() != '\r' && l.peek() != '=' {
 				l.next()
 			}
 			word := l.slice()

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -439,15 +439,15 @@ func TestLex_WhitespaceOnlyLine(t *testing.T) {
 	}
 }
 
-func TestLex_WordThenCommentNoSpace(t *testing.T) {
-	// Word stops at # so "word#rest" gives Value "word" then Comment "rest"
+func TestLex_HashInsideWord(t *testing.T) {
+	// OpenSSH treats # as data when it is part of an unquoted argument.
 	input := "Host server#note\n"
 	tokens, err := Lex(input)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tokens[1].Value != "server" || tokens[2].Kind != TokenComment || tokens[2].Value != "note" {
-		t.Errorf("word#comment: got %v", tokens)
+	if tokens[1].Kind != TokenValue || tokens[1].Value != "server#note" || tokens[2].Kind != TokenNewline {
+		t.Errorf("hash inside word: got %v", tokens)
 	}
 }
 

--- a/pkg/sshconfig/edit.go
+++ b/pkg/sshconfig/edit.go
@@ -156,11 +156,12 @@ func writeArguments(out *bytes.Buffer, arguments []string) {
 		if i > 0 {
 			out.WriteByte(' ')
 		}
-		out.WriteString(quoteArgument(argument))
+		out.WriteString(QuoteArgument(argument))
 	}
 }
 
-func quoteArgument(argument string) string {
+// QuoteArgument renders one argument so reparsing returns the same value.
+func QuoteArgument(argument string) string {
 	if argument != "" && !strings.ContainsAny(argument, " \t\r\n#\\\"'") {
 		return argument
 	}

--- a/pkg/sshconfig/migrate.go
+++ b/pkg/sshconfig/migrate.go
@@ -99,13 +99,13 @@ func writeLegacyHost(output *bytes.Buffer, name, notes string, config map[string
 		}
 	}
 	output.WriteString("Host ")
-	output.WriteString(quoteArgument(name))
+	output.WriteString(QuoteArgument(name))
 	output.WriteByte('\n')
 	for _, key := range sortedMapKeys(config) {
 		output.WriteString("    ")
 		output.WriteString(key)
 		output.WriteByte(' ')
-		output.WriteString(quoteArgument(config[key]))
+		output.WriteString(QuoteArgument(config[key]))
 		output.WriteByte('\n')
 	}
 }


### PR DESCRIPTION
## Summary

- treat `#` as data when it appears inside an unquoted OpenSSH argument
- quote single-value legacy directives when required for a stable round trip
- preserve `ProxyCommand` as a rest-of-line command
- add regression coverage for paths containing spaces and `#`

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`