### PR TITLE
fix: reject cross-line legacy fields

### DIFF
--- a/internal/parser/json.go
+++ b/internal/parser/json.go
@@ -65,5 +65,8 @@ func GroupJSONConfigStrict(input string) ([]Define.HostConfig, error) {
 		hostConfigs = append(hostConfigs, config)
 	}
 
+	if err := validateLegacyHostConfigs(hostConfigs); err != nil {
+		return nil, err
+	}
 	return hostConfigs, nil
 }

--- a/internal/parser/legacy_safety_test.go
+++ b/internal/parser/legacy_safety_test.go
@@ -18,6 +18,20 @@ func TestGroupStructuredConfigStrictReturnsDecodeErrors(t *testing.T) {
 	}
 }
 
+func TestGroupStructuredConfigRejectsCrossLineFields(t *testing.T) {
+	t.Parallel()
+
+	jsonInput := `[{"Name":"example","Data":{"User":"alice\nHost injected"}}]`
+	if _, err := Parser.GroupJSONConfigStrict(jsonInput); err == nil {
+		t.Fatal("GroupJSONConfigStrict() accepted a cross-line value")
+	}
+
+	yamlInput := "Group test:\n  Hosts:\n    example:\n      config:\n        'User\nProxyCommand': alice\n"
+	if _, err := Parser.GroupYAMLConfigStrict(yamlInput); err == nil {
+		t.Fatal("GroupYAMLConfigStrict() accepted a cross-line keyword")
+	}
+}
+
 func TestGroupSSHConfigRejectsLossyLegacyInputs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/parser/legacy_validate.go
+++ b/internal/parser/legacy_validate.go
@@ -1,0 +1,29 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+
+	Define "github.com/soulteary/ssh-config/v2/internal/define"
+	"github.com/soulteary/ssh-config/v2/pkg/sshconfig"
+)
+
+func validateLegacyHostConfigs(configs []Define.HostConfig) error {
+	for index, host := range configs {
+		name := host.Extra.Prefix + host.Name
+		if err := sshconfig.ValidateDirectiveInput("Host", []string{name}, ""); err != nil {
+			return fmt.Errorf("legacy host %d: %w", index, err)
+		}
+		for _, note := range strings.Split(host.Notes, "\n") {
+			if err := sshconfig.ValidateDirectiveInput("Host", nil, note); err != nil {
+				return fmt.Errorf("legacy host %d note: %w", index, err)
+			}
+		}
+		for key, value := range host.Config {
+			if err := sshconfig.ValidateDirectiveInput(key, []string{value}, ""); err != nil {
+				return fmt.Errorf("legacy host %d directive %q: %w", index, key, err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/parser/yaml.go
+++ b/internal/parser/yaml.go
@@ -192,5 +192,8 @@ func GroupYAMLConfigStrict(input string) ([]Define.HostConfig, error) {
 			}
 		}
 	}
+	if err := validateLegacyHostConfigs(hostConfigs); err != nil {
+		return nil, err
+	}
 	return hostConfigs, nil
 }

--- a/pkg/sshconfig/edit.go
+++ b/pkg/sshconfig/edit.go
@@ -13,7 +13,7 @@ func (d *Document) ReplaceDirective(id NodeID, keyword string, arguments ...stri
 	if d == nil {
 		return fmt.Errorf("sshconfig: nil document")
 	}
-	if err := validateDirectiveInput(keyword, arguments, ""); err != nil {
+	if err := ValidateDirectiveInput(keyword, arguments, ""); err != nil {
 		return err
 	}
 	index := d.nodeIndex(id)
@@ -50,7 +50,7 @@ func (d *Document) InsertDirectiveAfter(after NodeID, keyword string, arguments 
 	if d == nil {
 		return 0, fmt.Errorf("sshconfig: nil document")
 	}
-	if err := validateDirectiveInput(keyword, arguments, ""); err != nil {
+	if err := ValidateDirectiveInput(keyword, arguments, ""); err != nil {
 		return 0, err
 	}
 	index := d.nodeIndex(after)
@@ -76,7 +76,7 @@ func (d *Document) AppendDirective(keyword string, arguments ...string) (NodeID,
 	if d == nil {
 		return 0, fmt.Errorf("sshconfig: nil document")
 	}
-	if err := validateDirectiveInput(keyword, arguments, ""); err != nil {
+	if err := ValidateDirectiveInput(keyword, arguments, ""); err != nil {
 		return 0, err
 	}
 	raw := d.renderNewDirective(keyword, arguments)
@@ -187,7 +187,8 @@ func syntheticDirective(keyword string, arguments []string) *Directive {
 	}
 }
 
-func validateDirectiveInput(keyword string, arguments []string, comment string) error {
+// ValidateDirectiveInput rejects fields that could escape their directive line.
+func ValidateDirectiveInput(keyword string, arguments []string, comment string) error {
 	if keyword == "" {
 		return fmt.Errorf("sshconfig: directive keyword is empty")
 	}

--- a/pkg/sshconfig/migrate.go
+++ b/pkg/sshconfig/migrate.go
@@ -38,7 +38,9 @@ func MigrateLegacyYAML(data []byte, path string) (Schema, error) {
 		return Schema{}, fmt.Errorf("sshconfig: decode legacy YAML: %w", err)
 	}
 	var output bytes.Buffer
-	writeLegacyHost(&output, "*", "", legacy.Global)
+	if err := writeLegacyHost(&output, "*", "", legacy.Global); err != nil {
+		return Schema{}, err
+	}
 	groupNames := sortedMapKeys(legacy.Groups)
 	for _, groupName := range groupNames {
 		group := legacy.Groups[groupName]
@@ -51,7 +53,9 @@ func MigrateLegacyYAML(data []byte, path string) (Schema, error) {
 			}
 			mergeMissing(config, group.Common)
 			mergeMissing(config, legacy.Default)
-			writeLegacyHost(&output, group.Prefix+hostName, host.Notes, config)
+			if err := writeLegacyHost(&output, group.Prefix+hostName, host.Notes, config); err != nil {
+				return Schema{}, err
+			}
 		}
 	}
 	return schemaFromLegacyBytes(output.Bytes(), path)
@@ -70,7 +74,9 @@ func MigrateLegacyJSON(data []byte, path string) (Schema, error) {
 	}
 	var output bytes.Buffer
 	for _, host := range hosts {
-		writeLegacyHost(&output, host.Name, host.Notes, host.Data)
+		if err := writeLegacyHost(&output, host.Name, host.Notes, host.Data); err != nil {
+			return Schema{}, err
+		}
 	}
 	return schemaFromLegacyBytes(output.Bytes(), path)
 }
@@ -87,9 +93,22 @@ func schemaFromLegacyBytes(data []byte, path string) (Schema, error) {
 	return NewSchema(schemaDocument), nil
 }
 
-func writeLegacyHost(output *bytes.Buffer, name, notes string, config map[string]string) {
+func writeLegacyHost(output *bytes.Buffer, name, notes string, config map[string]string) error {
 	if name == "" || len(config) == 0 {
-		return
+		return nil
+	}
+	if err := ValidateDirectiveInput("Host", []string{name}, ""); err != nil {
+		return fmt.Errorf("sshconfig: invalid legacy host %q: %w", name, err)
+	}
+	for _, note := range strings.Split(notes, "\n") {
+		if err := ValidateDirectiveInput("Host", nil, note); err != nil {
+			return fmt.Errorf("sshconfig: invalid legacy note: %w", err)
+		}
+	}
+	for key, value := range config {
+		if err := ValidateDirectiveInput(key, []string{value}, ""); err != nil {
+			return fmt.Errorf("sshconfig: invalid legacy directive %q: %w", key, err)
+		}
 	}
 	for _, note := range strings.Split(notes, "\n") {
 		if note != "" {
@@ -108,6 +127,7 @@ func writeLegacyHost(output *bytes.Buffer, name, notes string, config map[string
 		output.WriteString(quoteArgument(config[key]))
 		output.WriteByte('\n')
 	}
+	return nil
 }
 
 func sortedMapKeys[V any](values map[string]V) []string {

--- a/pkg/sshconfig/schema.go
+++ b/pkg/sshconfig/schema.go
@@ -153,7 +153,7 @@ func (s Schema) Validate() error {
 				return fmt.Errorf("sshconfig: document %d node %d has an empty keyword", index, nodeIndex)
 			}
 			if node.Directive != nil {
-				if err := validateDirectiveInput(node.Directive.Keyword, node.Directive.Arguments, node.Directive.Comment); err != nil {
+				if err := ValidateDirectiveInput(node.Directive.Keyword, node.Directive.Arguments, node.Directive.Comment); err != nil {
 					return fmt.Errorf("sshconfig: document %d node %d: %w", index, nodeIndex, err)
 				}
 			}

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -267,6 +267,20 @@ Group production:
 	}
 }
 
+func TestMigrateLegacyFormatsRejectCrossLineFields(t *testing.T) {
+	t.Parallel()
+
+	legacyJSON := []byte(`[{"Name":"example","Data":{"User":"alice\nHost injected"}}]`)
+	if _, err := MigrateLegacyJSON(legacyJSON, "config"); err == nil {
+		t.Fatal("MigrateLegacyJSON() accepted a cross-line value")
+	}
+
+	legacyYAML := []byte("Group test:\n  Hosts:\n    'example\nHost injected':\n      config:\n        User: alice\n")
+	if _, err := MigrateLegacyYAML(legacyYAML, "config"); err == nil {
+		t.Fatal("MigrateLegacyYAML() accepted a cross-line host")
+	}
+}
+
 func assertSchemaDocumentBytes(t *testing.T, schema Schema, path string, want []byte) {
 	t.Helper()
 	doc, err := schema.Document(path)


### PR DESCRIPTION
## Summary

- validate legacy host names, notes, directive names, and values before rendering
- reject NUL and line endings that could create additional SSH directives
- apply the same validation to normal YAML/JSON conversion and lossless migration
- add regression tests for JSON and YAML injection attempts

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`