### PR TITLE
fix: preserve raw no-argument directives

### DIFF
--- a/pkg/sshconfig/schema.go
+++ b/pkg/sshconfig/schema.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"reflect"
+	"slices"
 	"unicode/utf8"
 
 	"gopkg.in/yaml.v2"
@@ -293,7 +293,9 @@ func schemaRawMatchesDirective(raw []byte, expected *SchemaDirective) bool {
 	if directive.Comment != nil {
 		actual.Comment = string(doc.source[directive.Comment.Span.Start:directive.Comment.Span.End])
 	}
-	return reflect.DeepEqual(actual, expected)
+	return actual.Keyword == expected.Keyword &&
+		actual.Comment == expected.Comment &&
+		slices.Equal(actual.Arguments, expected.Arguments)
 }
 
 func renderSchemaDirective(directive *SchemaDirective, lineEnding string, defaultLineEnding bool) []byte {

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -140,6 +140,30 @@ func TestSchemaEditPreservesMissingFinalNewline(t *testing.T) {
 	}
 }
 
+func TestSchemaPreservesRawDirectiveWithoutArguments(t *testing.T) {
+	t.Parallel()
+	input := []byte("  FutureOption\n")
+	doc, err := Parse(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	schemaDocument, err := doc.ToSchema("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reconstructed, err := schemaDocument.Document()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := reconstructed.MarshalPreserve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, input) {
+		t.Fatalf("schema round trip mismatch\n got: %q\nwant: %q", got, input)
+	}
+}
+
 func TestSchemaNewDirectiveDefaultsToLF(t *testing.T) {
 	t.Parallel()
 	schemaDocument := SchemaDocument{Nodes: []SchemaNode{{


### PR DESCRIPTION
## Summary

- compare schema argument slices semantically instead of distinguishing nil from empty
- keep untouched raw bytes for directives without arguments
- add regression coverage for indentation and line-ending preservation

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`