### PR TITLE
fix: preserve legacy host order

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/soulteary/ssh-config/v2
 
 go 1.27.0
 
-require gopkg.in/yaml.v2 v2.4.0
+require (
+	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/parser/legacy_safety_test.go
+++ b/internal/parser/legacy_safety_test.go
@@ -97,3 +97,61 @@ func TestLegacyConversionPreservesQuotedAndHashArguments(t *testing.T) {
 		t.Fatalf("round trip = %#v", reparsed[0].Config)
 	}
 }
+
+func TestLegacyRoundTripPreservesHostOrder(t *testing.T) {
+	t.Parallel()
+
+	input := "Host special.example.com\n  User special\nHost *.example.com\n  User wildcard\n"
+	configs, err := Parser.GroupSSHConfig(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	yamlData := Parser.ConvertToYAML(configs)
+	fromYAML, err := Parser.GroupYAMLConfigStrict(string(yamlData))
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := string(Parser.ConvertToSSH(fromYAML))
+	special := strings.Index(output, "Host special.example.com")
+	wildcard := strings.Index(output, "Host *.example.com")
+	if special < 0 || wildcard < 0 || special > wildcard {
+		t.Fatalf("host order changed:\n%s", output)
+	}
+}
+
+func TestLegacyYAMLPreservesHostsMappingOrder(t *testing.T) {
+	t.Parallel()
+
+	input := "Group work:\n  Hosts:\n    z-host:\n      config:\n        User: z\n    a-host:\n      config:\n        User: a\n"
+	configs, err := Parser.GroupYAMLConfigStrict(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := string(Parser.ConvertToSSH(configs))
+	if strings.Index(output, "Host z-host") > strings.Index(output, "Host a-host") {
+		t.Fatalf("host order changed:\n%s", output)
+	}
+}
+
+func TestLegacyYAMLPreservesMergedHostsOrder(t *testing.T) {
+	t.Parallel()
+
+	input := `Group template: &group
+  Hosts:
+    z-host:
+      config:
+        User: z
+    a-host:
+      config:
+        User: a
+Group inherited:
+  <<: *group
+`
+	configs, err := Parser.GroupYAMLConfigStrict(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(configs) != 4 || configs[2].Name != "z-host" || configs[3].Name != "a-host" {
+		t.Fatalf("merged host order = %#v", configs)
+	}
+}

--- a/internal/parser/ssh.go
+++ b/internal/parser/ssh.go
@@ -19,7 +19,6 @@ package parser
 import (
 	"fmt"
 	"reflect"
-	"slices"
 	"strings"
 
 	Define "github.com/soulteary/ssh-config/v2/internal/define"
@@ -146,15 +145,12 @@ func GroupSSHConfig(userInput string) ([]Define.HostConfig, error) {
 	if err := validateLegacySSHConfig(userInput); err != nil {
 		return nil, err
 	}
-	configs, err := GroupSSHConfigFromString(userInput)
+	tokens, err := lexer.Lex(userInput)
 	if err != nil {
 		return nil, err
 	}
-	hosts := make([]string, 0, len(configs))
-	for host := range configs {
-		hosts = append(hosts, host)
-	}
-	slices.Sort(hosts)
+	configs := groupFromTokens(tokens)
+	hosts := hostOrderFromTokens(tokens)
 
 	hostConfigs := make([]Define.HostConfig, 0, len(hosts))
 	for _, host := range hosts {
@@ -170,6 +166,29 @@ func GroupSSHConfig(userInput string) ([]Define.HostConfig, error) {
 		})
 	}
 	return hostConfigs, nil
+}
+
+func hostOrderFromTokens(tokens []lexer.Token) []string {
+	hosts := make([]string, 0)
+	for index := 0; index < len(tokens); index++ {
+		token := tokens[index]
+		if token.Kind != lexer.TokenKeyword || !strings.EqualFold(token.Value, "host") {
+			continue
+		}
+		parts := make([]string, 0)
+		for index+1 < len(tokens) {
+			next := tokens[index+1]
+			if next.Kind != lexer.TokenValue && next.Kind != lexer.TokenQuoted {
+				break
+			}
+			index++
+			parts = append(parts, next.Value)
+		}
+		if host := strings.TrimSpace(strings.Join(parts, " ")); host != "" {
+			hosts = append(hosts, host)
+		}
+	}
+	return hosts
 }
 
 func validateLegacySSHConfig(input string) error {

--- a/internal/parser/yaml.go
+++ b/internal/parser/yaml.go
@@ -300,7 +300,7 @@ func dereferenceYAMLAlias(node *yamlv3.Node) *yamlv3.Node {
 }
 
 func isYAMLMergeKey(node *yamlv3.Node) bool {
-	return node != nil && (node.Tag == "!!merge" || node.Value == "<<")
+	return node != nil && node.Tag == "!!merge"
 }
 
 func orderedLegacyKeys[V any](preferred []string, values map[string]V) []string {

--- a/internal/parser/yaml.go
+++ b/internal/parser/yaml.go
@@ -23,6 +23,7 @@ import (
 	Define "github.com/soulteary/ssh-config/v2/internal/define"
 	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
 	"gopkg.in/yaml.v2"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 // mapToMapSlice 将 map[string]string 转为按 key 排序的 yaml.MapSlice，保证输出顺序稳定。
@@ -101,7 +102,6 @@ func ConvertToYAML(hostConfigs []Define.HostConfig) []byte {
 			}
 			groupsData[groupName] = groupItems
 		}
-		slices.Sort(groupNames)
 		for _, groupName := range groupNames {
 			root = append(root, yaml.MapItem{Key: groupName, Value: groupsData[groupName]})
 		}
@@ -145,11 +145,8 @@ func GroupYAMLConfigStrict(input string) ([]Define.HostConfig, error) {
 	}
 
 	if yamlConfig.Groups != nil {
-		keys := make([]string, 0)
-		for key := range yamlConfig.Groups {
-			keys = append(keys, key)
-		}
-		slices.Sort(keys)
+		groupOrder := legacyYAMLGroupOrder(input)
+		keys := orderedLegacyKeys(groupOrder.groups, yamlConfig.Groups)
 
 		for _, groupName := range keys {
 			groupConfig := yamlConfig.Groups[groupName]
@@ -159,11 +156,7 @@ func GroupYAMLConfigStrict(input string) ([]Define.HostConfig, error) {
 				prefix = groupConfig.Prefix
 			}
 
-			hostNames := make([]string, 0, len(groupConfig.Hosts))
-			for hostName := range groupConfig.Hosts {
-				hostNames = append(hostNames, hostName)
-			}
-			slices.Sort(hostNames)
+			hostNames := orderedLegacyKeys(groupOrder.hosts[groupName], groupConfig.Hosts)
 
 			for _, hostName := range hostNames {
 				originConfig := groupConfig.Hosts[hostName]
@@ -196,4 +189,139 @@ func GroupYAMLConfigStrict(input string) ([]Define.HostConfig, error) {
 		return nil, err
 	}
 	return hostConfigs, nil
+}
+
+type yamlOrder struct {
+	groups []string
+	hosts  map[string][]string
+}
+
+func legacyYAMLGroupOrder(input string) yamlOrder {
+	order := yamlOrder{hosts: make(map[string][]string)}
+	var document yamlv3.Node
+	if err := yamlv3.Unmarshal([]byte(input), &document); err != nil || len(document.Content) == 0 {
+		return order
+	}
+	for _, group := range resolvedYAMLMapping(document.Content[0], make(map[*yamlv3.Node]bool)) {
+		groupName := group.key.Value
+		if groupName == "global" || groupName == "default" {
+			continue
+		}
+		order.groups = append(order.groups, groupName)
+		for _, field := range resolvedYAMLMapping(group.value, make(map[*yamlv3.Node]bool)) {
+			if field.key.Value != "Hosts" {
+				continue
+			}
+			for _, host := range resolvedYAMLMapping(field.value, make(map[*yamlv3.Node]bool)) {
+				order.hosts[groupName] = append(order.hosts[groupName], host.key.Value)
+			}
+		}
+	}
+	return order
+}
+
+type yamlNodeEntry struct {
+	key   *yamlv3.Node
+	value *yamlv3.Node
+}
+
+func resolvedYAMLMapping(node *yamlv3.Node, visiting map[*yamlv3.Node]bool) []yamlNodeEntry {
+	node = dereferenceYAMLAlias(node)
+	if node == nil || node.Kind != yamlv3.MappingNode || visiting[node] {
+		return nil
+	}
+	visiting[node] = true
+	defer delete(visiting, node)
+
+	explicit := make(map[string]struct{})
+	for index := 0; index+1 < len(node.Content); index += 2 {
+		key := node.Content[index]
+		if !isYAMLMergeKey(key) {
+			explicit[key.Value] = struct{}{}
+		}
+	}
+
+	result := make([]yamlNodeEntry, 0, len(node.Content)/2)
+	seen := make(map[string]struct{})
+	appendEntry := func(entry yamlNodeEntry, merged bool) {
+		name := entry.key.Value
+		if merged {
+			if _, overridden := explicit[name]; overridden {
+				return
+			}
+		}
+		if _, exists := seen[name]; exists {
+			return
+		}
+		seen[name] = struct{}{}
+		result = append(result, entry)
+	}
+
+	for index := 0; index+1 < len(node.Content); index += 2 {
+		key, value := node.Content[index], node.Content[index+1]
+		if !isYAMLMergeKey(key) {
+			appendEntry(yamlNodeEntry{key: key, value: value}, false)
+			continue
+		}
+		for _, entry := range resolvedYAMLMerge(value, visiting) {
+			appendEntry(entry, true)
+		}
+	}
+	return result
+}
+
+func resolvedYAMLMerge(node *yamlv3.Node, visiting map[*yamlv3.Node]bool) []yamlNodeEntry {
+	node = dereferenceYAMLAlias(node)
+	if node == nil {
+		return nil
+	}
+	if node.Kind == yamlv3.SequenceNode {
+		var result []yamlNodeEntry
+		seen := make(map[string]struct{})
+		for _, item := range node.Content {
+			for _, entry := range resolvedYAMLMapping(item, visiting) {
+				if _, exists := seen[entry.key.Value]; exists {
+					continue
+				}
+				seen[entry.key.Value] = struct{}{}
+				result = append(result, entry)
+			}
+		}
+		return result
+	}
+	return resolvedYAMLMapping(node, visiting)
+}
+
+func dereferenceYAMLAlias(node *yamlv3.Node) *yamlv3.Node {
+	for node != nil && node.Kind == yamlv3.AliasNode {
+		node = node.Alias
+	}
+	return node
+}
+
+func isYAMLMergeKey(node *yamlv3.Node) bool {
+	return node != nil && (node.Tag == "!!merge" || node.Value == "<<")
+}
+
+func orderedLegacyKeys[V any](preferred []string, values map[string]V) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, key := range preferred {
+		if _, exists := values[key]; !exists {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, key)
+	}
+	missing := make([]string, 0, len(values)-len(result))
+	for key := range values {
+		if _, exists := seen[key]; !exists {
+			missing = append(missing, key)
+		}
+	}
+	slices.Sort(missing)
+	return append(result, missing...)
 }


### PR DESCRIPTION
## Summary

- retain source order when grouping SSH `Host` blocks
- preserve top-level group and nested host mapping order when decoding legacy YAML
- resolve YAML merge keys and aliases through the YAML AST before deriving order
- keep explicit mappings authoritative while expanding inherited entries at the merge position
- add regressions for overlapping hosts and merged `Hosts` mappings

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

Updated onto the current `main` after #39–#42.