### PR TITLE
fix: inherit defaults for empty hosts

### DIFF
--- a/internal/parser/legacy_safety_test.go
+++ b/internal/parser/legacy_safety_test.go
@@ -32,6 +32,28 @@ func TestGroupStructuredConfigRejectsCrossLineFields(t *testing.T) {
 	}
 }
 
+func TestGroupYAMLConfigAppliesInheritanceToEmptyHost(t *testing.T) {
+	t.Parallel()
+	input := `default:
+  User: alice
+Group work:
+  Common:
+    Port: "22"
+  Hosts:
+    example: {}
+`
+	configs, err := Parser.GroupYAMLConfigStrict(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(configs) != 1 {
+		t.Fatalf("GroupYAMLConfigStrict() returned %d hosts, want 1", len(configs))
+	}
+	if configs[0].Name != "example" || configs[0].Config["User"] != "alice" || configs[0].Config["Port"] != "22" {
+		t.Fatalf("inherited host = %#v", configs[0])
+	}
+}
+
 func TestGroupSSHConfigRejectsLossyLegacyInputs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/parser/yaml.go
+++ b/internal/parser/yaml.go
@@ -170,6 +170,9 @@ func GroupYAMLConfigStrict(input string) ([]Define.HostConfig, error) {
 				hostConfig := originConfig
 				hostConfig.Name = hostName
 				hostConfig.Extra.Prefix = prefix
+				if hostConfig.Config == nil && (len(groupConfig.Common) > 0 || len(yamlConfig.Default) > 0) {
+					hostConfig.Config = make(map[string]string)
+				}
 				if hostConfig.Config != nil {
 					if groupConfig.Common != nil {
 						for key, value := range groupConfig.Common {


### PR DESCRIPTION
## Summary

- initialize an empty host config when group or document defaults provide inherited values
- retain the existing behavior for empty hosts without inherited configuration
- add regression coverage for combined `Default` and `Common` inheritance

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

Rebased onto the current `main` after #39–#42.