### PR TITLE
fix: preserve v3 YAML merge precedence

### DIFF
--- a/pkg/sshconfig/schema.go
+++ b/pkg/sshconfig/schema.go
@@ -9,7 +9,7 @@ import (
 	"slices"
 	"unicode/utf8"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // SchemaVersion is the lossless structured configuration format version.
@@ -232,8 +232,17 @@ func MarshalSchemaYAML(schema Schema) ([]byte, error) {
 // UnmarshalSchemaYAML strictly decodes one YAML schema document.
 func UnmarshalSchemaYAML(data []byte) (Schema, error) {
 	var schema Schema
-	if err := yaml.UnmarshalStrict(data, &schema); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&schema); err != nil {
 		return Schema{}, fmt.Errorf("sshconfig: decode v3 YAML: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err != nil {
+			return Schema{}, fmt.Errorf("sshconfig: decode trailing v3 YAML: %w", err)
+		}
+		return Schema{}, fmt.Errorf("sshconfig: multiple YAML documents are not allowed")
 	}
 	if err := schema.Validate(); err != nil {
 		return Schema{}, err

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -232,6 +232,44 @@ func TestSchemaStrictValidation(t *testing.T) {
 	}
 }
 
+func TestSchemaYAMLMergeExplicitValuesWin(t *testing.T) {
+	t.Parallel()
+	inputs := []string{
+		"schemaVersion: 3\ndocuments:\n- nodes:\n  - type: directive\n    directive:\n      <<: {keyword: ProxyCommand, arguments: [evil]}\n      keyword: Host\n      arguments: [safe]\n",
+		"schemaVersion: 3\ndocuments:\n- nodes:\n  - type: directive\n    directive:\n      keyword: Host\n      arguments: [safe]\n      <<: {keyword: ProxyCommand, arguments: [evil]}\n",
+	}
+	for _, input := range inputs {
+		schema, err := UnmarshalSchemaYAML([]byte(input))
+		if err != nil {
+			t.Fatalf("UnmarshalSchemaYAML() error = %v", err)
+		}
+		doc, err := schema.Document("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		output, err := doc.MarshalPreserve()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(output) != "Host safe\n" {
+			t.Fatalf("merged directive = %q, want Host safe", output)
+		}
+	}
+}
+
+func TestSchemaYAMLRejectsAmbiguousDocuments(t *testing.T) {
+	t.Parallel()
+	inputs := []string{
+		"schemaVersion: 3\ndocuments:\n- nodes:\n  - type: directive\n    directive:\n      <<: {keyword: Host, keyword: Match, arguments: [safe]}\n",
+		"schemaVersion: 3\ndocuments:\n- nodes: []\n---\nschemaVersion: 3\ndocuments:\n- nodes: []\n",
+	}
+	for _, input := range inputs {
+		if _, err := UnmarshalSchemaYAML([]byte(input)); err == nil {
+			t.Fatalf("UnmarshalSchemaYAML() accepted ambiguous input:\n%s", input)
+		}
+	}
+}
+
 func TestSchemaRejectsCrossLineDirectiveFields(t *testing.T) {
 	t.Parallel()
 	tests := []SchemaDirective{
@@ -339,7 +377,6 @@ func TestMigrateLegacyYAMLRejectsDuplicateMergeOperands(t *testing.T) {
 		t.Fatal("MigrateLegacyYAML() accepted duplicate fields inside a merge operand")
 	}
 }
-
 
 func TestMigrateLegacyYAMLRejectsQuotedMergeKeyAsUnknownField(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- decode v3 YAML with yaml.v3 strict known-field checks
- keep explicit directive fields authoritative whether they appear before or after `<<`
- reject duplicate merge operands and multiple YAML documents
- add regressions for both merge-key positions

## Validation

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`