### PR TITLE
fix: read long stdin lines without truncation

### DIFF
--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -17,7 +17,6 @@
 package fn
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -39,13 +38,14 @@ var (
 )
 
 func GetUserInputFromStdin() string {
-	var lines []string
-	scanner := bufio.NewScanner(os.Stdin)
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-	input := strings.Join(lines, "\n")
-	return input
+	input, _ := ReadUserInputFromStdin()
+	return string(input)
+}
+
+// ReadUserInputFromStdin reads standard input without Scanner's token-size
+// limit and returns any underlying read error to the caller.
+func ReadUserInputFromStdin() ([]byte, error) {
+	return io.ReadAll(os.Stdin)
 }
 
 type OrderedMap struct {

--- a/internal/fn/fn_test.go
+++ b/internal/fn/fn_test.go
@@ -55,6 +55,11 @@ func TestGetUserInputFromStdin(t *testing.T) {
 			input:    "",
 			expected: "",
 		},
+		{
+			name:     "Line larger than Scanner limit",
+			input:    "Host " + strings.Repeat("a", 70*1024),
+			expected: "Host " + strings.Repeat("a", 70*1024),
+		},
 	}
 
 	for _, tt := range tests {

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -45,7 +44,7 @@ type Dependencies struct {
 	SaveFile              func(string, []byte) error
 	SaveLossless          func(string, []byte) error
 	GetUserInputFromStdin func() string
-	GetLosslessStdin      func() ([]byte, error)
+	ReadStdin             func() ([]byte, error)
 	WriteOutput           func([]byte) error
 	Process               func(string, string, Cmd.Args) ([]byte, error)
 	CheckUseStdin         func() bool
@@ -62,8 +61,8 @@ func Run(args Cmd.Args, deps Dependencies) error {
 	pipeMode := deps.CheckUseStdin()
 	var userInput string
 	if pipeMode {
-		if args.Lossless && deps.GetLosslessStdin != nil {
-			input, err := deps.GetLosslessStdin()
+		if deps.ReadStdin != nil {
+			input, err := deps.ReadStdin()
 			if err != nil {
 				deps.errorln("Error reading stdin:", err)
 				return err
@@ -169,7 +168,7 @@ func MainWithDependencies(exit func(int), userHomeDir func() (string, error)) {
 		SaveFile:              atomicSave,
 		SaveLossless:          atomicSave,
 		GetUserInputFromStdin: Fn.GetUserInputFromStdin,
-		GetLosslessStdin:      func() ([]byte, error) { return io.ReadAll(os.Stdin) },
+		ReadStdin:             Fn.ReadUserInputFromStdin,
 		WriteOutput: func(data []byte) error {
 			_, err := os.Stdout.Write(data)
 			return err

--- a/main_test.go
+++ b/main_test.go
@@ -219,7 +219,7 @@ func TestRunLosslessPipePreservesInputAndOutputBytes(t *testing.T) {
 			t.Fatal("line-oriented stdin reader called")
 			return ""
 		},
-		GetLosslessStdin: func() ([]byte, error) { return input, nil },
+		ReadStdin: func() ([]byte, error) { return input, nil },
 		Process: func(_ string, got string, _ Cmd.Args) ([]byte, error) {
 			if !bytes.Equal([]byte(got), input) {
 				t.Fatalf("processor input = %q, want %q", got, input)
@@ -259,7 +259,7 @@ func TestRunLosslessReadsItsStructuredOutput(t *testing.T) {
 			err = Run(Cmd.Args{ToSSH: true, Lossless: true}, Dependencies{
 				Println:               func(...interface{}) (int, error) { return 0, nil },
 				CheckUseStdin:         func() bool { return true },
-				GetLosslessStdin:      func() ([]byte, error) { return structured, nil },
+				ReadStdin:             func() ([]byte, error) { return structured, nil },
 				GetUserInputFromStdin: func() string { t.Fatal("legacy stdin reader called"); return "" },
 				Process:               Parser.Process,
 				WriteOutput: func(data []byte) error {
@@ -274,6 +274,18 @@ func TestRunLosslessReadsItsStructuredOutput(t *testing.T) {
 				t.Fatalf("round trip mismatch\n got: %q\nwant: %q", output, original)
 			}
 		})
+	}
+}
+
+func TestRunReportsStdinReadErrorsInLegacyMode(t *testing.T) {
+	wantErr := errors.New("stdin failed")
+	err := Run(Cmd.Args{ToYAML: true}, Dependencies{
+		Println:       func(...interface{}) (int, error) { return 0, nil },
+		CheckUseStdin: func() bool { return true },
+		ReadStdin:     func() ([]byte, error) { return nil, wantErr },
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Run() error = %v, want %v", err, wantErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the line-oriented stdin Scanner path with `io.ReadAll`
- remove the implicit 64 KiB per-line limit from legacy pipeline input
- return stdin read failures through the CLI instead of silently continuing
- retain the existing string helper for compatibility
- add regressions for 70 KiB lines and legacy-mode read errors

## Validation

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`