### PR TITLE
fix: preserve host order during legacy YAML migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
 ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 ```
 
-The previous YAML/JSON formats remain the default for compatibility. Lossless mode can import them, but ordering and repeated values already discarded by a legacy map cannot be reconstructed.
+The previous YAML/JSON formats remain the default for compatibility. Lossless mode can import them and retains YAML group and host source order, but repeated values and directive ordering not represented by a legacy map cannot be reconstructed.
 
 See the [lossless schema v3 specification](./docs/lossless-schema-v3.md) for node shapes, byte-preservation rules, editing behavior, API examples, and migration limits.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -108,7 +108,7 @@ ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
 ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 ```
 
-为保持兼容，默认仍使用原有 YAML/JSON 格式。无损模式能够导入旧格式，但无法恢复已经被旧 map 结构丢弃的顺序和重复值。
+为保持兼容，默认仍使用原有 YAML/JSON 格式。无损模式能够导入旧格式并保留 YAML 中 Group 和 Host 的源顺序，但无法恢复旧 map 结构未表达的重复值和指令顺序。
 
 字段结构、字节保持规则、编辑行为、Go API 示例和旧格式迁移边界详见 [v3 无损格式规范](./docs/lossless-schema-v3.md)。
 

--- a/docs/lossless-schema-v3.md
+++ b/docs/lossless-schema-v3.md
@@ -113,12 +113,13 @@ SSH source.
 ## Legacy migration
 
 Lossless mode accepts the previous map-based YAML and host-array JSON formats
-and migrates them deterministically into v3. Migration sorts map keys, applies
-legacy `Default` and `Common` values using the existing precedence rules, and
-emits a concrete v3 document.
+and migrates them deterministically into v3. YAML group and host source order,
+including order inherited through merge aliases, is retained because SSH host
+precedence is order-sensitive. Directive map keys are sorted, and legacy
+`Default` and `Common` values use the existing precedence rules.
 
 Migration cannot recover information that the legacy representation never
-stored, including directive order, duplicate keys, physical comments and
+stored, including repeated directive values, physical comments and
 spacing, `Match` structure, `Include` boundaries, or unknown directives that
 were discarded earlier. Keep an original SSH source file when exact recovery
 matters.

--- a/pkg/sshconfig/migrate.go
+++ b/pkg/sshconfig/migrate.go
@@ -37,6 +37,10 @@ func MigrateLegacyYAML(data []byte, path string) (Schema, error) {
 	if err := ValidateLegacyYAML(data); err != nil {
 		return Schema{}, fmt.Errorf("sshconfig: decode legacy YAML: %w", err)
 	}
+	order, err := legacyYAMLSourceOrder(data)
+	if err != nil {
+		return Schema{}, fmt.Errorf("sshconfig: decode legacy YAML order: %w", err)
+	}
 	if err := yaml.Unmarshal(data, &legacy); err != nil {
 		return Schema{}, fmt.Errorf("sshconfig: decode legacy YAML: %w", err)
 	}
@@ -44,10 +48,10 @@ func MigrateLegacyYAML(data []byte, path string) (Schema, error) {
 	if err := writeLegacyHost(&output, "*", "", legacy.Global); err != nil {
 		return Schema{}, err
 	}
-	groupNames := sortedMapKeys(legacy.Groups)
+	groupNames := orderedLegacyMapKeys(order.groups, legacy.Groups)
 	for _, groupName := range groupNames {
 		group := legacy.Groups[groupName]
-		hostNames := sortedMapKeys(group.Hosts)
+		hostNames := orderedLegacyMapKeys(order.hosts[groupName], group.Hosts)
 		for _, hostName := range hostNames {
 			host := group.Hosts[hostName]
 			config := cloneStringMap(host.Config)
@@ -62,6 +66,73 @@ func MigrateLegacyYAML(data []byte, path string) (Schema, error) {
 		}
 	}
 	return schemaFromLegacyBytes(output.Bytes(), path)
+}
+
+type legacyYAMLOrder struct {
+	groups []string
+	hosts  map[string][]string
+}
+
+func legacyYAMLSourceOrder(data []byte) (legacyYAMLOrder, error) {
+	order := legacyYAMLOrder{hosts: make(map[string][]string)}
+	var document yaml.Node
+	if err := yaml.Unmarshal(data, &document); err != nil {
+		return order, err
+	}
+	if len(document.Content) == 0 {
+		return order, nil
+	}
+	groups, err := legacyYAMLMappingEntries(document.Content[0], "document")
+	if err != nil {
+		return order, err
+	}
+	for _, group := range groups {
+		groupName := group.key.Value
+		if groupName == "global" || groupName == "default" {
+			continue
+		}
+		order.groups = append(order.groups, groupName)
+		fields, err := legacyYAMLMappingEntries(group.value, groupName)
+		if err != nil {
+			return order, err
+		}
+		for _, field := range fields {
+			if field.key.Value != "Hosts" {
+				continue
+			}
+			hosts, err := legacyYAMLMappingEntries(field.value, groupName+".Hosts")
+			if err != nil {
+				return order, err
+			}
+			for _, host := range hosts {
+				order.hosts[groupName] = append(order.hosts[groupName], host.key.Value)
+			}
+		}
+	}
+	return order, nil
+}
+
+func orderedLegacyMapKeys[V any](preferred []string, values map[string]V) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, key := range preferred {
+		if _, exists := values[key]; !exists {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, key)
+	}
+	missing := make([]string, 0, len(values)-len(result))
+	for key := range values {
+		if _, exists := seen[key]; !exists {
+			missing = append(missing, key)
+		}
+	}
+	sort.Strings(missing)
+	return append(result, missing...)
 }
 
 // MigrateLegacyJSON converts the previous host-array JSON format into v3.

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -340,12 +340,81 @@ func TestMigrateLegacyYAMLRejectsDuplicateMergeOperands(t *testing.T) {
 	}
 }
 
-
 func TestMigrateLegacyYAMLRejectsQuotedMergeKeyAsUnknownField(t *testing.T) {
 	t.Parallel()
 	input := []byte("Group work:\n  \"<<\": {}\n")
 	if _, err := MigrateLegacyYAML(input, "config"); err == nil || !strings.Contains(err.Error(), "unknown YAML field") {
 		t.Fatalf("MigrateLegacyYAML() error = %v, want unknown field error", err)
+	}
+}
+
+func TestMigrateLegacyYAMLPreservesGroupAndHostOrder(t *testing.T) {
+	t.Parallel()
+	input := []byte(`Group z:
+  Hosts:
+    special.example.com:
+      config:
+        User: special
+    '*.example.com':
+      config:
+        User: wildcard
+Group a:
+  Hosts:
+    last.example.com:
+      config:
+        User: last
+`)
+	schema, err := MigrateLegacyYAML(input, "config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := schema.Document("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := doc.MarshalPreserve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	special := strings.Index(string(output), "Host special.example.com")
+	wildcard := strings.Index(string(output), "Host *.example.com")
+	last := strings.Index(string(output), "Host last.example.com")
+	if special < 0 || wildcard < 0 || last < 0 || !(special < wildcard && wildcard < last) {
+		t.Fatalf("migration changed group or host order:\n%s", output)
+	}
+}
+
+func TestMigrateLegacyYAMLPreservesMergedHostOrder(t *testing.T) {
+	t.Parallel()
+	input := []byte(`Group template: &group
+  Prefix: template-
+  Hosts:
+    z-host:
+      config:
+        User: z
+    a-host:
+      config:
+        User: a
+Group inherited:
+  <<: *group
+  Prefix: inherited-
+`)
+	schema, err := MigrateLegacyYAML(input, "config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := schema.Document("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := doc.MarshalPreserve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	z := strings.Index(string(output), "Host inherited-z-host")
+	a := strings.Index(string(output), "Host inherited-a-host")
+	if z < 0 || a < 0 || z > a {
+		t.Fatalf("migration changed inherited host order:\n%s", output)
 	}
 }
 


### PR DESCRIPTION
## Summary

- derive legacy YAML group and host order from the yaml.v3 node graph before map decoding
- retain order inherited through YAML merge aliases while keeping explicit keys authoritative
- fall back deterministically for keys absent from the source-order view
- update English, Chinese, and schema migration documentation
- add regressions for ordinary and merged host mappings

## Validation

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`