### PR TITLE
ci: tier workflows by event

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,10 +4,16 @@ on:
   workflow_dispatch:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/github-repo-card.png"
   schedule:
     - cron: '15 0 * * 2'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3,20 +3,56 @@ name: Quality
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/github-repo-card.png"
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/github-repo-card.png"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: quality-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test, vet and vulnerability scan
+  pull-request:
+    if: github.event_name == 'pull_request'
+    name: PR tests and vet
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Verify module files
+        run: go mod tidy -diff
+
+      - name: Test
+        run: go test ./...
+
+      - name: Vet
+        run: go vet ./...
+
+  main:
+    if: github.event_name != 'pull_request'
+    name: Main tests, coverage and vulnerability scan
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## Summary

- keep pull-request checks lightweight: module consistency, unit tests, and vet
- reserve race detection, coverage upload, and vulnerability scanning for `main` and manual runs
- run CodeQL on `main`, the weekly schedule, and manual dispatch instead of every pull request
- skip code-oriented workflows for documentation-only changes
- cancel superseded runs using workflow/PR-aware concurrency groups

Release builds remain tag/manual-only and continue publishing through GitHub Releases.

## Verification

- parsed both workflow files as YAML
- `go mod tidy -diff`
- `go test ./...`
- `go vet ./...`
- `git diff --check`