### PR TITLE
fix: reject ambiguous schema document paths

### DIFF
--- a/pkg/sshconfig/schema.go
+++ b/pkg/sshconfig/schema.go
@@ -89,14 +89,20 @@ func NewSchema(documents ...SchemaDocument) Schema {
 	return Schema{SchemaVersion: SchemaVersion, Documents: documents}
 }
 
-// Document reconstructs one schema document. An empty path selects the first
-// document when the schema contains exactly one document.
+// Document reconstructs one schema document. An empty path selects the
+// document only when the schema contains exactly one document.
 func (s Schema) Document(path string) (*Document, error) {
 	if err := s.Validate(); err != nil {
 		return nil, err
 	}
+	if path == "" {
+		if len(s.Documents) != 1 {
+			return nil, fmt.Errorf("sshconfig: an empty document path requires exactly one schema document")
+		}
+		return s.Documents[0].Document()
+	}
 	for _, document := range s.Documents {
-		if document.Path == path || path == "" && len(s.Documents) == 1 {
+		if document.Path == path {
 			return document.Document()
 		}
 	}
@@ -137,12 +143,13 @@ func (s Schema) Validate() error {
 	}
 	seen := make(map[string]bool)
 	for index, document := range s.Documents {
-		if document.Path != "" {
-			if seen[document.Path] {
-				return fmt.Errorf("sshconfig: duplicate schema document path %q", document.Path)
-			}
-			seen[document.Path] = true
+		if len(s.Documents) > 1 && document.Path == "" {
+			return fmt.Errorf("sshconfig: document %d has an empty path in a multi-document schema", index)
 		}
+		if seen[document.Path] {
+			return fmt.Errorf("sshconfig: duplicate schema document path %q", document.Path)
+		}
+		seen[document.Path] = true
 		for nodeIndex, node := range document.Nodes {
 			switch node.Type {
 			case "blank", "comment", "directive", "invalid":

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -232,6 +232,33 @@ func TestSchemaStrictValidation(t *testing.T) {
 	}
 }
 
+func TestSchemaDocumentPathSelection(t *testing.T) {
+	t.Parallel()
+
+	single := NewSchema(SchemaDocument{})
+	if _, err := single.Document(""); err != nil {
+		t.Fatalf("single document with empty path was not selectable: %v", err)
+	}
+
+	for _, documents := range [][]SchemaDocument{
+		{{}, {}},
+		{{}, {Path: "config.d/work"}},
+	} {
+		schema := NewSchema(documents...)
+		if err := schema.Validate(); err == nil || !strings.Contains(err.Error(), "empty path in a multi-document schema") {
+			t.Fatalf("Validate() error = %v, want empty multi-document path error", err)
+		}
+	}
+
+	multiple := NewSchema(
+		SchemaDocument{Path: "config"},
+		SchemaDocument{Path: "config.d/work"},
+	)
+	if _, err := multiple.Document(""); err == nil || !strings.Contains(err.Error(), "requires exactly one schema document") {
+		t.Fatalf("Document(\"\") error = %v, want ambiguous selector error", err)
+	}
+}
+
 func TestSchemaYAMLMergeExplicitValuesWin(t *testing.T) {
 	t.Parallel()
 	inputs := []string{


### PR DESCRIPTION
## Summary

- require every document path to be non-empty when a schema contains multiple documents
- make an empty document selector valid only for single-document schemas
- cover single-document selection, multiple empty paths, mixed empty/named paths, and ambiguous empty selection

## Why

A multi-document schema could contain empty paths and still pass validation. Calling `Document("")` could then select the first empty-path document instead of reporting an ambiguous selector.

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`