### PR TITLE
docs: align CLI usage with behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SSH Config Tool is a command-line utility for managing SSH configuration files. 
 - Converts classic SSH config files into YAML or JSON for easier editing and review
 - Scans a single file or an entire directory tree (such as `~/.ssh`) while skipping key material and other non-config files
 - Supports reading configuration from files or standard input (stdin)
-- Supports output to files or standard output (stdout), creating parent folders when needed
+- Supports output to files or standard output (stdout)
 - Automatically detects the input format (YAML/JSON/SSH Config) and tidies trailing blank lines
 - Offers an opt-in lossless v3 format that preserves comments, ordering, repeated directives, quoting, line endings, and unknown directives
 
@@ -82,7 +82,7 @@ cat /ssh/test.yaml | ssh-config -to-yaml
 
 - `-to-yaml, -to-json, -to-ssh`: Specify output format (yaml/json/config), only one output format can be specified at a time.
 - `-src`: Specify the original configuration file or directory to read from. When omitted, the tool scans `~/.ssh`.
-- `-dest`: Specify the path to save the configuration file. When omitted, the converted result is written to standard output.
+- `-dest`: Specify the path to save the configuration file. Its parent directory must already exist. When omitted, the converted result is written to standard output.
 - `-lossless`: Use the lossless parser and v3 YAML/JSON schema. This mode accepts one source file or stdin and writes destination files atomically.
 - `-help`: View program command-line help
 - `-version`: Print release, commit, build, and tree-state metadata

--- a/README_CN.md
+++ b/README_CN.md
@@ -33,7 +33,19 @@ brew install soulteary/tap/ssh-config
 ### 基本用法
 
 ```bash
-ssh-config [options] <input_file> <output_file>
+ssh-config [options]
+```
+
+不带参数运行时，程序会扫描 `~/.ssh` 下的 SSH 配置，并将 YAML 输出到标准输出：
+
+```bash
+ssh-config
+```
+
+需要指定输入和输出文件时，请使用 `-src` 和 `-dest`：
+
+```bash
+ssh-config -to-yaml -src input_file -dest output_file
 ```
 
 或，使用 Linux 管道来操作文件：
@@ -74,8 +86,8 @@ cat /ssh/test.yaml | ssh-config -to-yaml
 ### 选项
 
 - `-to-yaml, -to-json, -to-ssh`: 指定输出格式 (yaml/json/config)，同一时间，输出格式只能指定为一种。
-- `-src`: 指定要读取的原始配置文件，或配置目录
-- `-dest`: 指定要保存的配置文件路径
+- `-src`: 指定要读取的原始配置文件或配置目录；省略时扫描 `~/.ssh`
+- `-dest`: 指定要保存的配置文件路径；父目录必须已存在，省略时将转换结果写入标准输出
 - `-lossless`: 使用无损解析器和 v3 YAML/JSON 格式。此模式接受单个源文件或标准输入，并以原子方式写入目标文件。
 - `-help`: 查看程序命令行帮助
 - `-version`: 输出发布版本、提交、构建时间和工作树状态


### PR DESCRIPTION
## Summary

- remove the incorrect claim that destination parent directories are created automatically
- document that `-dest` requires an existing parent directory
- replace the Chinese positional-argument example with the actual `-src` and `-dest` flag syntax
- document the default `~/.ssh` scan and stdout behavior in Chinese

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go vet ./...`
- `git diff --check`