### PR TITLE
feat: make lossless conversion the default

### DIFF
--- a/cmd/argv.go
+++ b/cmd/argv.go
@@ -31,9 +31,12 @@ var (
 )
 
 type Args struct {
-	ToYAML   bool
-	ToSSH    bool
-	ToJSON   bool
+	ToYAML bool
+	ToSSH  bool
+	ToJSON bool
+	// Lossless is retained as a deprecated compatibility alias. Lossless
+	// conversion is always enabled unless Legacy is set.
+	Lossless bool
 	Legacy   bool
 	Src      string
 	Dest     string
@@ -42,20 +45,22 @@ type Args struct {
 }
 
 const (
-	DEFAULT_TO_YAML = false
-	DEFAULT_TO_SSH  = false
-	DEFAULT_TO_JSON = false
-	DEFAULT_LEGACY  = false
-	DEFAULT_SRC     = ""
-	DEFAULT_DEST    = ""
-	DEFAULT_HELP    = false
-	DEFAULT_VERSION = false
+	DEFAULT_TO_YAML  = false
+	DEFAULT_TO_SSH   = false
+	DEFAULT_TO_JSON  = false
+	DEFAULT_LOSSLESS = false
+	DEFAULT_LEGACY   = false
+	DEFAULT_SRC      = ""
+	DEFAULT_DEST     = ""
+	DEFAULT_HELP     = false
+	DEFAULT_VERSION  = false
 )
 
 func initFlags() {
 	flag.BoolVar(&args.ToYAML, "to-yaml", DEFAULT_TO_YAML, "Convert SSH config(Text/JSON) to YAML")
 	flag.BoolVar(&args.ToSSH, "to-ssh", DEFAULT_TO_SSH, "Convert SSH config(YAML/JSON) to SSH config")
 	flag.BoolVar(&args.ToJSON, "to-json", DEFAULT_TO_JSON, "Convert SSH config(YAML/Text) to JSON")
+	flag.BoolVar(&args.Lossless, "lossless", DEFAULT_LOSSLESS, "Deprecated: lossless conversion is now the default")
 	flag.BoolVar(&args.Legacy, "legacy", DEFAULT_LEGACY, "Use the legacy lossy conversion format")
 	flag.StringVar(&args.Src, "src", DEFAULT_SRC, "Source file or directories path, valid when using non-pipeline mode")
 	flag.StringVar(&args.Dest, "dest", DEFAULT_DEST, "Destination file path, valid when using non-pipeline mode")
@@ -77,6 +82,7 @@ func ResetFlags() {
 		ToYAML:   DEFAULT_TO_YAML,
 		ToSSH:    DEFAULT_TO_SSH,
 		ToJSON:   DEFAULT_TO_JSON,
+		Lossless: DEFAULT_LOSSLESS,
 		Legacy:   DEFAULT_LEGACY,
 		Src:      DEFAULT_SRC,
 		Dest:     DEFAULT_DEST,

--- a/cmd/argv.go
+++ b/cmd/argv.go
@@ -34,7 +34,7 @@ type Args struct {
 	ToYAML   bool
 	ToSSH    bool
 	ToJSON   bool
-	Lossless bool
+	Legacy   bool
 	Src      string
 	Dest     string
 	ShowHelp bool
@@ -42,21 +42,21 @@ type Args struct {
 }
 
 const (
-	DEFAULT_TO_YAML  = false
-	DEFAULT_TO_SSH   = false
-	DEFAULT_TO_JSON  = false
-	DEFAULT_LOSSLESS = false
-	DEFAULT_SRC      = ""
-	DEFAULT_DEST     = ""
-	DEFAULT_HELP     = false
-	DEFAULT_VERSION  = false
+	DEFAULT_TO_YAML = false
+	DEFAULT_TO_SSH  = false
+	DEFAULT_TO_JSON = false
+	DEFAULT_LEGACY  = false
+	DEFAULT_SRC     = ""
+	DEFAULT_DEST    = ""
+	DEFAULT_HELP    = false
+	DEFAULT_VERSION = false
 )
 
 func initFlags() {
 	flag.BoolVar(&args.ToYAML, "to-yaml", DEFAULT_TO_YAML, "Convert SSH config(Text/JSON) to YAML")
 	flag.BoolVar(&args.ToSSH, "to-ssh", DEFAULT_TO_SSH, "Convert SSH config(YAML/JSON) to SSH config")
 	flag.BoolVar(&args.ToJSON, "to-json", DEFAULT_TO_JSON, "Convert SSH config(YAML/Text) to JSON")
-	flag.BoolVar(&args.Lossless, "lossless", DEFAULT_LOSSLESS, "Use the lossless v3 parser and structured format")
+	flag.BoolVar(&args.Legacy, "legacy", DEFAULT_LEGACY, "Use the legacy lossy conversion format")
 	flag.StringVar(&args.Src, "src", DEFAULT_SRC, "Source file or directories path, valid when using non-pipeline mode")
 	flag.StringVar(&args.Dest, "dest", DEFAULT_DEST, "Destination file path, valid when using non-pipeline mode")
 	flag.BoolVar(&args.ShowHelp, "help", DEFAULT_HELP, "Show help")
@@ -77,7 +77,7 @@ func ResetFlags() {
 		ToYAML:   DEFAULT_TO_YAML,
 		ToSSH:    DEFAULT_TO_SSH,
 		ToJSON:   DEFAULT_TO_JSON,
-		Lossless: DEFAULT_LOSSLESS,
+		Legacy:   DEFAULT_LEGACY,
 		Src:      DEFAULT_SRC,
 		Dest:     DEFAULT_DEST,
 		ShowHelp: DEFAULT_HELP,
@@ -130,8 +130,8 @@ func CheckIOArgvValid(args Args) (result bool, desc string) {
 	if err != nil {
 		return false, fmt.Sprintf("Error: Can not inspect source path '%s': %v", args.Src, err)
 	}
-	if args.Lossless && info.IsDir() {
-		return false, "Lossless mode requires a single source file or standard input"
+	if !args.Legacy && info.IsDir() {
+		return false, "Lossless conversion requires a single source file or standard input; use -legacy to scan a directory"
 	}
 
 	// allow empty dest

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -125,7 +125,7 @@ func TestCheckIOArgvValid(t *testing.T) {
 		},
 		{
 			name:       "Valid directory to non-existent directory",
-			args:       Cmd.Args{Src: testDir, Dest: filepath.Join(tempDir, "newdir")},
+			args:       Cmd.Args{Src: testDir, Dest: filepath.Join(tempDir, "newdir"), Legacy: true},
 			wantResult: true,
 			wantDesc:   "",
 		},
@@ -154,10 +154,16 @@ func TestCheckIOArgvValid(t *testing.T) {
 			wantDesc:   "",
 		},
 		{
-			name:       "Lossless mode rejects a source directory",
-			args:       Cmd.Args{Src: testDir, Lossless: true},
+			name:       "Default lossless mode rejects a source directory",
+			args:       Cmd.Args{Src: testDir},
 			wantResult: false,
-			wantDesc:   "Lossless mode requires a single source file or standard input",
+			wantDesc:   "Lossless conversion requires a single source file or standard input; use -legacy to scan a directory",
+		},
+		{
+			name:       "Legacy mode accepts a source directory",
+			args:       Cmd.Args{Src: testDir, Legacy: true},
+			wantResult: true,
+			wantDesc:   "",
 		},
 	}
 
@@ -266,12 +272,12 @@ func TestParseArgs(t *testing.T) {
 		},
 		{
 			name: "Set all flags",
-			args: []string{"-to-yaml", "-to-ssh", "-to-json", "-lossless", "-src", "source.txt", "-dest", "destination.txt", "-help", "-version"},
+			args: []string{"-to-yaml", "-to-ssh", "-to-json", "-legacy", "-src", "source.txt", "-dest", "destination.txt", "-help", "-version"},
 			expected: Cmd.Args{
 				ToYAML:   true,
 				ToSSH:    true,
 				ToJSON:   true,
-				Lossless: true,
+				Legacy:   true,
 				Src:      "source.txt",
 				Dest:     "destination.txt",
 				ShowHelp: true,
@@ -360,7 +366,7 @@ func TestResetFlags(t *testing.T) {
 	if result.ToYAML != expected.ToYAML {
 		t.Errorf("After ResetFlags(), ParseArgs() = %v, want %v", result, expected)
 	}
-	if result.Lossless != expected.Lossless {
+	if result.Legacy != expected.Legacy {
 		t.Errorf("After ResetFlags(), ParseArgs() = %v, want %v", result, expected)
 	}
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -272,11 +272,12 @@ func TestParseArgs(t *testing.T) {
 		},
 		{
 			name: "Set all flags",
-			args: []string{"-to-yaml", "-to-ssh", "-to-json", "-legacy", "-src", "source.txt", "-dest", "destination.txt", "-help", "-version"},
+			args: []string{"-to-yaml", "-to-ssh", "-to-json", "-lossless", "-legacy", "-src", "source.txt", "-dest", "destination.txt", "-help", "-version"},
 			expected: Cmd.Args{
 				ToYAML:   true,
 				ToSSH:    true,
 				ToJSON:   true,
+				Lossless: true,
 				Legacy:   true,
 				Src:      "source.txt",
 				Dest:     "destination.txt",
@@ -364,6 +365,9 @@ func TestResetFlags(t *testing.T) {
 		t.Errorf("After ResetFlags(), ParseArgs() = %v, want %v", result, expected)
 	}
 	if result.ToYAML != expected.ToYAML {
+		t.Errorf("After ResetFlags(), ParseArgs() = %v, want %v", result, expected)
+	}
+	if result.Lossless != expected.Lossless {
 		t.Errorf("After ResetFlags(), ParseArgs() = %v, want %v", result, expected)
 	}
 	if result.Legacy != expected.Legacy {

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -22,9 +22,9 @@ const Usage = `Usage:
   ssh-config -to-yaml
   ssh-config -to-ssh
   ssh-config -to-json
-  ssh-config -lossless -to-yaml -src <SSH config file>
-  ssh-config -lossless -to-ssh -src <v3 YAML or JSON file>
-  ssh-config -src <source file or directories path> -dest <destination file path>
+  ssh-config -to-yaml -src <SSH config file>
+  ssh-config -to-ssh -src <v3 YAML or JSON file>
+  ssh-config -legacy -src <source file or directory> -dest <destination file>
   ssh-config -help
   ssh-config -version
 `

--- a/internal/parser/legacy_safety_test.go
+++ b/internal/parser/legacy_safety_test.go
@@ -78,8 +78,8 @@ func TestGroupSSHConfigRejectsLossyLegacyInputs(t *testing.T) {
 			if err == nil {
 				t.Fatal("GroupSSHConfig() unexpectedly succeeded")
 			}
-			if !strings.Contains(err.Error(), test.want) || !strings.Contains(err.Error(), "use -lossless") {
-				t.Fatalf("GroupSSHConfig() error = %q, want %q and lossless hint", err, test.want)
+			if !strings.Contains(err.Error(), test.want) || !strings.Contains(err.Error(), "retry without -legacy") {
+				t.Fatalf("GroupSSHConfig() error = %q, want %q and default-mode hint", err, test.want)
 			}
 		})
 	}

--- a/internal/parser/lossless_test.go
+++ b/internal/parser/lossless_test.go
@@ -13,14 +13,14 @@ func TestProcessLosslessSSHThroughStructuredFormats(t *testing.T) {
 	t.Parallel()
 	input := "# keep\r\nHost=example\r\n\tIdentityFile first\r\n\tIdentityFile second # backup\r\n"
 
-	yamlData, err := Parser.Process("TEXT", input, Cmd.Args{ToYAML: true, Lossless: true})
+	yamlData, err := Parser.Process("TEXT", input, Cmd.Args{ToYAML: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(string(yamlData), "schemaVersion: 3") || !strings.Contains(string(yamlData), "rawBase64:") {
 		t.Fatalf("lossless YAML does not contain the v3 envelope:\n%s", yamlData)
 	}
-	yamlBack, err := Parser.Process("YAML", string(yamlData), Cmd.Args{ToSSH: true, Lossless: true})
+	yamlBack, err := Parser.Process("YAML", string(yamlData), Cmd.Args{ToSSH: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,11 +28,11 @@ func TestProcessLosslessSSHThroughStructuredFormats(t *testing.T) {
 		t.Fatalf("YAML round trip mismatch\n got: %q\nwant: %q", yamlBack, input)
 	}
 
-	jsonData, err := Parser.Process("TEXT", input, Cmd.Args{ToJSON: true, Lossless: true})
+	jsonData, err := Parser.Process("TEXT", input, Cmd.Args{ToJSON: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	jsonBack, err := Parser.Process("YAML", string(jsonData), Cmd.Args{ToSSH: true, Lossless: true})
+	jsonBack, err := Parser.Process("YAML", string(jsonData), Cmd.Args{ToSSH: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +44,7 @@ func TestProcessLosslessSSHThroughStructuredFormats(t *testing.T) {
 func TestProcessLosslessMigratesLegacyJSON(t *testing.T) {
 	t.Parallel()
 	input := `[{"Name":"example","Data":{"User":"root"}}]`
-	got, err := Parser.Process("JSON", input, Cmd.Args{ToSSH: true, Lossless: true})
+	got, err := Parser.Process("JSON", input, Cmd.Args{ToSSH: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestProcessLosslessMigratesLegacyJSON(t *testing.T) {
 
 func TestProcessLosslessRejectsInvalidStructuredInput(t *testing.T) {
 	t.Parallel()
-	_, err := Parser.Process("YAML", "schemaVersion: 9\ndocuments: []\n", Cmd.Args{ToSSH: true, Lossless: true})
+	_, err := Parser.Process("YAML", "schemaVersion: 9\ndocuments: []\n", Cmd.Args{ToSSH: true})
 	if err == nil {
 		t.Fatal("invalid structured input was accepted")
 	}
@@ -73,7 +73,7 @@ func TestProcessLosslessDetectsReorderedV3YAML(t *testing.T) {
       - example
 schemaVersion: 3
 `
-	got, err := Parser.Process("TEXT", input, Cmd.Args{ToSSH: true, Lossless: true})
+	got, err := Parser.Process("TEXT", input, Cmd.Args{ToSSH: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -25,7 +25,7 @@ import (
 )
 
 func Process(fileType string, userInput string, args Cmd.Args) ([]byte, error) {
-	if args.Lossless {
+	if !args.Legacy {
 		return ProcessLossless(fileType, userInput, args)
 	}
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -59,21 +59,21 @@ func TestProcess(t *testing.T) {
 			name:     "YAML to SSH",
 			fileType: "YAML",
 			input:    string(yamlContent),
-			args:     Cmd.Args{ToSSH: true},
+			args:     Cmd.Args{ToSSH: true, Legacy: true},
 			want:     sshContent,
 		},
 		{
 			name:     "JSON to YAML",
 			fileType: "JSON",
 			input:    string(jsonContent),
-			args:     Cmd.Args{ToYAML: true},
+			args:     Cmd.Args{ToYAML: true, Legacy: true},
 			want:     yamlContent,
 		},
 		{
 			name:     "TEXT to JSON",
 			fileType: "TEXT",
 			input:    string(sshContent),
-			args:     Cmd.Args{ToJSON: true},
+			args:     Cmd.Args{ToJSON: true, Legacy: true},
 			want:     jsonContent,
 		},
 		{
@@ -138,7 +138,7 @@ func TestProcess(t *testing.T) {
 
 func TestProcess_InvalidTEXT_ReturnsError(t *testing.T) {
 	// 未闭合引号会使 Lex 报错，进而 GroupSSHConfig 返回 error
-	_, err := Parser.Process("TEXT", `Host "unclosed`, Cmd.Args{ToYAML: true})
+	_, err := Parser.Process("TEXT", `Host "unclosed`, Cmd.Args{ToYAML: true, Legacy: true})
 	if err == nil {
 		t.Error("Process() expected error for invalid TEXT input, got nil")
 	}

--- a/internal/parser/ssh.go
+++ b/internal/parser/ssh.go
@@ -248,7 +248,7 @@ func validateLegacySSHConfig(input string) error {
 }
 
 func legacyLossError(line int, reason string) error {
-	return fmt.Errorf("legacy conversion would lose data at line %d: %s; use -lossless", line, reason)
+	return fmt.Errorf("legacy conversion would lose data at line %d: %s; retry without -legacy", line, reason)
 }
 
 func nodeLine(node sshconfig.Node) int {

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func Run(args Cmd.Args, deps Dependencies) error {
 	}
 
 	fileType := Fn.DetectStringType(userInput)
-	if !args.Lossless {
+	if args.Legacy {
 		var err error
 		fileType, err = Fn.DetectStringTypeStrict(userInput)
 		if err != nil {
@@ -102,7 +102,7 @@ func Run(args Cmd.Args, deps Dependencies) error {
 	}
 
 	if pipeMode {
-		if args.Lossless && deps.WriteOutput != nil {
+		if !args.Legacy && deps.WriteOutput != nil {
 			if err := deps.WriteOutput(result); err != nil {
 				deps.errorln("Error writing output:", err)
 				return err
@@ -112,7 +112,7 @@ func Run(args Cmd.Args, deps Dependencies) error {
 		}
 	} else {
 		if args.Dest == "" {
-			if args.Lossless && deps.WriteOutput != nil {
+			if !args.Legacy && deps.WriteOutput != nil {
 				if err := deps.WriteOutput(result); err != nil {
 					deps.errorln("Error writing output:", err)
 					return err
@@ -124,7 +124,7 @@ func Run(args Cmd.Args, deps Dependencies) error {
 		}
 
 		save := deps.SaveFile
-		if args.Lossless && deps.SaveLossless != nil {
+		if !args.Legacy && deps.SaveLossless != nil {
 			save = deps.SaveLossless
 		}
 		err := save(args.Dest, result)
@@ -186,7 +186,8 @@ func MainWithDependencies(exit func(int), userHomeDir func() (string, error)) {
 		return
 	}
 
-	// default src to ~/.ssh
+	// Lossless conversion works on one physical file so source bytes and file
+	// boundaries remain unambiguous. Legacy mode retains the v2 directory scan.
 	if args.Src == "" {
 		homeDir, err := userHomeDir()
 		if err != nil {
@@ -194,7 +195,7 @@ func MainWithDependencies(exit func(int), userHomeDir func() (string, error)) {
 			exit(1)
 			return
 		}
-		args.Src = filepath.Join(homeDir, ".ssh")
+		args.Src = defaultSource(homeDir, args.Legacy)
 	}
 
 	// default to YAML when no conversion flag is provided
@@ -205,6 +206,13 @@ func MainWithDependencies(exit func(int), userHomeDir func() (string, error)) {
 	if err := Run(args, deps); err != nil {
 		exit(1)
 	}
+}
+
+func defaultSource(homeDir string, legacy bool) string {
+	if legacy {
+		return filepath.Join(homeDir, ".ssh")
+	}
+	return filepath.Join(homeDir, ".ssh", "config")
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	Cmd "github.com/soulteary/ssh-config/v2/cmd"
@@ -184,13 +185,13 @@ func TestRun(t *testing.T) {
 	}
 }
 
-func TestRunUsesAtomicSaverInLosslessMode(t *testing.T) {
+func TestRunUsesAtomicSaverByDefault(t *testing.T) {
 	source := path.Join(t.TempDir(), "input.yaml")
 	if err := os.WriteFile(source, []byte("schema"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	atomicCalled := false
-	err := Run(Cmd.Args{ToSSH: true, Lossless: true, Src: source, Dest: "config"}, Dependencies{
+	err := Run(Cmd.Args{ToSSH: true, Src: source, Dest: "config"}, Dependencies{
 		Println:       func(...interface{}) (int, error) { return 0, nil },
 		CheckUseStdin: func() bool { return false },
 		GetContent:    func(string) ([]byte, error) { return []byte("schema"), nil },
@@ -209,10 +210,10 @@ func TestRunUsesAtomicSaverInLosslessMode(t *testing.T) {
 	}
 }
 
-func TestRunLosslessPipePreservesInputAndOutputBytes(t *testing.T) {
+func TestRunDefaultPipePreservesInputAndOutputBytes(t *testing.T) {
 	input := []byte("Host=example\r\nIdentityFile first\r\nIdentityFile second")
 	var output []byte
-	err := Run(Cmd.Args{ToSSH: true, Lossless: true}, Dependencies{
+	err := Run(Cmd.Args{ToSSH: true}, Dependencies{
 		Println:       func(...interface{}) (int, error) { return 0, nil },
 		CheckUseStdin: func() bool { return true },
 		GetUserInputFromStdin: func() string {
@@ -239,14 +240,14 @@ func TestRunLosslessPipePreservesInputAndOutputBytes(t *testing.T) {
 	}
 }
 
-func TestRunLosslessReadsItsStructuredOutput(t *testing.T) {
+func TestRunDefaultModeReadsItsStructuredOutput(t *testing.T) {
 	original := []byte("Host=example\r\nIdentityFile first\r\nIdentityFile second")
 	formats := []struct {
 		name string
 		args Cmd.Args
 	}{
-		{name: "YAML", args: Cmd.Args{ToYAML: true, Lossless: true}},
-		{name: "JSON", args: Cmd.Args{ToJSON: true, Lossless: true}},
+		{name: "YAML", args: Cmd.Args{ToYAML: true}},
+		{name: "JSON", args: Cmd.Args{ToJSON: true}},
 	}
 
 	for _, format := range formats {
@@ -256,7 +257,7 @@ func TestRunLosslessReadsItsStructuredOutput(t *testing.T) {
 				t.Fatal(err)
 			}
 			var output []byte
-			err = Run(Cmd.Args{ToSSH: true, Lossless: true}, Dependencies{
+			err = Run(Cmd.Args{ToSSH: true}, Dependencies{
 				Println:               func(...interface{}) (int, error) { return 0, nil },
 				CheckUseStdin:         func() bool { return true },
 				ReadStdin:             func() ([]byte, error) { return structured, nil },
@@ -279,7 +280,7 @@ func TestRunLosslessReadsItsStructuredOutput(t *testing.T) {
 
 func TestRunReportsStdinReadErrorsInLegacyMode(t *testing.T) {
 	wantErr := errors.New("stdin failed")
-	err := Run(Cmd.Args{ToYAML: true}, Dependencies{
+	err := Run(Cmd.Args{ToYAML: true, Legacy: true}, Dependencies{
 		Println:       func(...interface{}) (int, error) { return 0, nil },
 		CheckUseStdin: func() bool { return true },
 		ReadStdin:     func() ([]byte, error) { return nil, wantErr },
@@ -399,6 +400,16 @@ func TestMainWithDependencies(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestDefaultSourceDependsOnConversionMode(t *testing.T) {
+	home := filepath.Join("home", "user")
+	if got, want := defaultSource(home, false), filepath.Join(home, ".ssh", "config"); got != want {
+		t.Fatalf("default lossless source = %q, want %q", got, want)
+	}
+	if got, want := defaultSource(home, true), filepath.Join(home, ".ssh"); got != want {
+		t.Fatalf("legacy source = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make the lossless v3 schema pipeline the default for YAML and JSON conversion
- replace the opt-in `-lossless` flag with an explicit `-legacy` compatibility mode
- read `~/.ssh/config` by default so one physical file retains unambiguous boundaries
- retain the v2 `~/.ssh` directory scan when `-legacy` is selected
- preserve byte-exact stdin/stdout and atomic destination writes in the default mode
- update legacy data-loss errors to tell users to retry without `-legacy`

## Compatibility

Legacy YAML and JSON remain readable in the default mode and are migrated to schema v3. Directory input remains available through `-legacy`.

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- combined v3 CLI smoke tests

Recommended merge order: this PR, Go module v3, v3 documentation, release verification.