### PR TITLE
build: migrate Go module to v3

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	Cmd "github.com/soulteary/ssh-config/v2/cmd"
+	Cmd "github.com/soulteary/ssh-config/v3/cmd"
 )
 
 func TestCheckConvertArgvValid(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/soulteary/ssh-config/v2
+module github.com/soulteary/ssh-config/v3
 
 go 1.27.0
 

--- a/integration/public_api_test.go
+++ b/integration/public_api_test.go
@@ -1,0 +1,25 @@
+package integration_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/soulteary/ssh-config/v3/pkg/sshconfig"
+)
+
+func TestV3PublicImportPath(t *testing.T) {
+	t.Parallel()
+
+	input := []byte("Host example\n  User deploy\n")
+	document, err := sshconfig.Parse(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := document.MarshalPreserve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(output, input) {
+		t.Fatalf("round trip = %q, want %q", output, input)
+	}
+}

--- a/internal/fn/config.go
+++ b/internal/fn/config.go
@@ -17,7 +17,7 @@
 package fn
 
 import (
-	Define "github.com/soulteary/ssh-config/v2/internal/define"
+	Define "github.com/soulteary/ssh-config/v3/internal/define"
 )
 
 func FindGlobalConfig(configs []Define.HostConfig) (result []Define.HostConfig) {

--- a/internal/fn/config_test.go
+++ b/internal/fn/config_test.go
@@ -20,8 +20,8 @@ import (
 	"reflect"
 	"testing"
 
-	Define "github.com/soulteary/ssh-config/v2/internal/define"
-	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
+	Define "github.com/soulteary/ssh-config/v3/internal/define"
+	Fn "github.com/soulteary/ssh-config/v3/internal/fn"
 )
 
 func TestFindGlobalConfig(t *testing.T) {

--- a/internal/fn/decode_strict_test.go
+++ b/internal/fn/decode_strict_test.go
@@ -3,7 +3,7 @@ package fn_test
 import (
 	"testing"
 
-	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
+	Fn "github.com/soulteary/ssh-config/v3/internal/fn"
 )
 
 func TestGetYamlDataStrictRejectsUnknownAndDuplicateFields(t *testing.T) {

--- a/internal/fn/detect_strict_test.go
+++ b/internal/fn/detect_strict_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
+	Fn "github.com/soulteary/ssh-config/v3/internal/fn"
 )
 
 func TestDetectStringTypeStrictRejectsMalformedStructuredInput(t *testing.T) {

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -25,7 +25,7 @@ import (
 	"slices"
 	"strings"
 
-	Define "github.com/soulteary/ssh-config/v2/internal/define"
+	Define "github.com/soulteary/ssh-config/v3/internal/define"
 	"gopkg.in/yaml.v2"
 	yamlv3 "gopkg.in/yaml.v3"
 )

--- a/internal/fn/fn_test.go
+++ b/internal/fn/fn_test.go
@@ -27,8 +27,8 @@ import (
 	"strings"
 	"testing"
 
-	Define "github.com/soulteary/ssh-config/v2/internal/define"
-	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
+	Define "github.com/soulteary/ssh-config/v3/internal/define"
+	Fn "github.com/soulteary/ssh-config/v3/internal/fn"
 )
 
 func TestGetUserInputFromStdin(t *testing.T) {

--- a/internal/fn/scanner.go
+++ b/internal/fn/scanner.go
@@ -23,8 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/soulteary/ssh-config/v2/internal/define"
-	"github.com/soulteary/ssh-config/v2/pkg/sshconfig"
+	"github.com/soulteary/ssh-config/v3/internal/define"
+	"github.com/soulteary/ssh-config/v3/pkg/sshconfig"
 )
 
 const maxScannedConfigLine = 1024 * 1024

--- a/internal/fn/scanner_test.go
+++ b/internal/fn/scanner_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/soulteary/ssh-config/v2/internal/fn"
+	"github.com/soulteary/ssh-config/v3/internal/fn"
 )
 
 func TestIsExcluded(t *testing.T) {

--- a/internal/fn/yaml_strict.go
+++ b/internal/fn/yaml_strict.go
@@ -1,6 +1,6 @@
 package fn
 
-import "github.com/soulteary/ssh-config/v2/pkg/sshconfig"
+import "github.com/soulteary/ssh-config/v3/pkg/sshconfig"
 
 func validateLegacyYAML(data []byte) error {
 	return sshconfig.ValidateLegacyYAML(data)

--- a/internal/parser/json.go
+++ b/internal/parser/json.go
@@ -19,8 +19,8 @@ package parser
 import (
 	"fmt"
 
-	Define "github.com/soulteary/ssh-config/v2/internal/define"
-	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
+	Define "github.com/soulteary/ssh-config/v3/internal/define"
+	Fn "github.com/soulteary/ssh-config/v3/internal/fn"
 )
 
 func ConvertToJSON(input []Define.HostConfig) []byte {

--- a/internal/parser/json_test.go
+++ b/internal/parser/json_test.go
@@ -21,8 +21,8 @@ import (
 	"reflect"
 	"testing"
 
-	Define "github.com/soulteary/ssh-config/v2/internal/define"
-	Parser "github.com/soulteary/ssh-config/v2/internal/parser"
+	Define "github.com/soulteary/ssh-config/v3/internal/define"
+	Parser "github.com/soulteary/ssh-config/v3/internal/parser"
 )
 
 func TestConvertToJSON(t *testing.T) {

--- a/internal/parser/legacy_safety_test.go
+++ b/internal/parser/legacy_safety_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	Parser "github.com/soulteary/ssh-config/v2/internal/parser"
+	Parser "github.com/soulteary/ssh-config/v3/internal/parser"
 )
 
 func TestGroupStructuredConfigStrictReturnsDecodeErrors(t *testing.T) {

--- a/internal/parser/legacy_validate.go
+++ b/internal/parser/legacy_validate.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	Define "github.com/soulteary/ssh-config/v2/internal/define"
-	"github.com/soulteary/ssh-config/v2/pkg/sshconfig"
+	Define "github.com/soulteary/ssh-config/v3/internal/define"
+	"github.com/soulteary/ssh-config/v3/pkg/sshconfig"
 )
 
 func validateLegacyHostConfigs(configs []Define.HostConfig) error {

--- a/internal/parser/lossless.go
+++ b/internal/parser/lossless.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	Cmd "github.com/soulteary/ssh-config/v2/cmd"
-	"github.com/soulteary/ssh-config/v2/pkg/sshconfig"
+	Cmd "github.com/soulteary/ssh-config/v3/cmd"
+	"github.com/soulteary/ssh-config/v3/pkg/sshconfig"
 )
 
 // ProcessLossless converts SSH source or a v3 structured document without

--- a/internal/parser/lossless_test.go
+++ b/internal/parser/lossless_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	Cmd "github.com/soulteary/ssh-config/v2/cmd"
-	Parser "github.com/soulteary/ssh-config/v2/internal/parser"
+	Cmd "github.com/soulteary/ssh-config/v3/cmd"
+	Parser "github.com/soulteary/ssh-config/v3/internal/parser"
 )
 
 func TestProcessLosslessSSHThroughStructuredFormats(t *testing.T) {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -19,9 +19,9 @@ package parser
 import (
 	"strings"
 
-	Cmd "github.com/soulteary/ssh-config/v2/cmd"
-	Define "github.com/soulteary/ssh-config/v2/internal/define"
-	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
+	Cmd "github.com/soulteary/ssh-config/v3/cmd"
+	Define "github.com/soulteary/ssh-config/v3/internal/define"
+	Fn "github.com/soulteary/ssh-config/v3/internal/fn"
 )
 
 func Process(fileType string, userInput string, args Cmd.Args) ([]byte, error) {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -22,9 +22,9 @@ import (
 	"reflect"
 	"testing"
 
-	Cmd "github.com/soulteary/ssh-config/v2/cmd"
-	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
-	Parser "github.com/soulteary/ssh-config/v2/internal/parser"
+	Cmd "github.com/soulteary/ssh-config/v3/cmd"
+	Fn "github.com/soulteary/ssh-config/v3/internal/fn"
+	Parser "github.com/soulteary/ssh-config/v3/internal/parser"
 )
 
 func TestProcess(t *testing.T) {

--- a/internal/parser/ssh.go
+++ b/internal/parser/ssh.go
@@ -21,10 +21,10 @@ import (
 	"reflect"
 	"strings"
 
-	Define "github.com/soulteary/ssh-config/v2/internal/define"
-	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
-	"github.com/soulteary/ssh-config/v2/pkg/lexer"
-	"github.com/soulteary/ssh-config/v2/pkg/sshconfig"
+	Define "github.com/soulteary/ssh-config/v3/internal/define"
+	Fn "github.com/soulteary/ssh-config/v3/internal/fn"
+	"github.com/soulteary/ssh-config/v3/pkg/lexer"
+	"github.com/soulteary/ssh-config/v3/pkg/sshconfig"
 )
 
 var legacySSHDirectives = map[string]struct{}{

--- a/internal/parser/ssh_test.go
+++ b/internal/parser/ssh_test.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"testing"
 
-	Define "github.com/soulteary/ssh-config/v2/internal/define"
-	Parser "github.com/soulteary/ssh-config/v2/internal/parser"
+	Define "github.com/soulteary/ssh-config/v3/internal/define"
+	Parser "github.com/soulteary/ssh-config/v3/internal/parser"
 )
 
 func TestGroupSSHConfigFromString(t *testing.T) {

--- a/internal/parser/yaml.go
+++ b/internal/parser/yaml.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"slices"
 
-	Define "github.com/soulteary/ssh-config/v2/internal/define"
-	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
+	Define "github.com/soulteary/ssh-config/v3/internal/define"
+	Fn "github.com/soulteary/ssh-config/v3/internal/fn"
 	"gopkg.in/yaml.v2"
 	yamlv3 "gopkg.in/yaml.v3"
 )

--- a/internal/parser/yaml_test.go
+++ b/internal/parser/yaml_test.go
@@ -22,9 +22,9 @@ import (
 	"reflect"
 	"testing"
 
-	Define "github.com/soulteary/ssh-config/v2/internal/define"
-	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
-	Parser "github.com/soulteary/ssh-config/v2/internal/parser"
+	Define "github.com/soulteary/ssh-config/v3/internal/define"
+	Fn "github.com/soulteary/ssh-config/v3/internal/fn"
+	Parser "github.com/soulteary/ssh-config/v3/internal/parser"
 )
 
 func TestConvertToYAML(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -21,10 +21,10 @@ import (
 	"os"
 	"path/filepath"
 
-	Cmd "github.com/soulteary/ssh-config/v2/cmd"
-	Fn "github.com/soulteary/ssh-config/v2/internal/fn"
-	Parser "github.com/soulteary/ssh-config/v2/internal/parser"
-	"github.com/soulteary/ssh-config/v2/pkg/sshconfig"
+	Cmd "github.com/soulteary/ssh-config/v3/cmd"
+	Fn "github.com/soulteary/ssh-config/v3/internal/fn"
+	Parser "github.com/soulteary/ssh-config/v3/internal/parser"
+	"github.com/soulteary/ssh-config/v3/pkg/sshconfig"
 )
 
 var (

--- a/main_test.go
+++ b/main_test.go
@@ -24,8 +24,8 @@ import (
 	"path"
 	"testing"
 
-	Cmd "github.com/soulteary/ssh-config/v2/cmd"
-	Parser "github.com/soulteary/ssh-config/v2/internal/parser"
+	Cmd "github.com/soulteary/ssh-config/v3/cmd"
+	Parser "github.com/soulteary/ssh-config/v3/internal/parser"
 )
 
 func TestRun(t *testing.T) {


### PR DESCRIPTION
## Summary

- change the module path to `github.com/soulteary/ssh-config/v3`
- update every internal import to the v3 semantic import path
- add an external consumer test that imports `github.com/soulteary/ssh-config/v3/pkg/sshconfig`

## Why

A `v3.0.0` tag is not valid for a module that still declares a `/v2` path. This change keeps the tag, module identity, and public import paths aligned.

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- combined successfully with the default-lossless change

Recommended merge order: after the default-lossless PR and before the documentation/release PRs.