### PR TITLE
docs: prepare v3 migration and release guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ ssh-config [options]
 Run without arguments to export `~/.ssh/config` as lossless v3 YAML on standard output:
 
 ```bash
-ssh-config
+ssh-config -lossless
 ```
 
 Or, use Linux pipes to manipulate files:
 
 ```bash
-cat input_file | ssh-config -to-yaml > output_file
+cat input_file | ssh-config -lossless -to-yaml > output_file
 ```
 
 ### Docker
@@ -68,20 +68,20 @@ docker pull ghcr.io/soulteary/ssh-config:latest
 Convert file (test.yaml) in the current directory to YAML (abc.yaml):
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
+docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -lossless -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
 ```
 
 Just want to see the conversion results:
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -to-yaml -src /ssh/test.yaml
+docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -lossless -to-yaml -src /ssh/test.yaml
 ```
 
 If you want to use Linux pipelines, you can first enter the Docker interactive command line:
 
 ```bash
 docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest bash
-cat /ssh/test.yaml | ssh-config -to-yaml
+cat /ssh/test.yaml | ssh-config -lossless -to-yaml
 ```
 
 ### Options
@@ -90,6 +90,7 @@ cat /ssh/test.yaml | ssh-config -to-yaml
 - `-src`: Specify the source file. When omitted, lossless mode reads `~/.ssh/config`; legacy mode scans `~/.ssh`.
 - `-dest`: Specify the path to save the configuration file. Its parent directory must already exist. When omitted, the converted result is written to standard output.
 - `-legacy`: Use the previous lossy map/array formats. This mode also enables directory scanning.
+- `-lossless`: Deprecated compatibility alias; lossless conversion is already the default in v3.
 - `-help`: View program command-line help
 - `-version`: Print release, commit, build, and tree-state metadata
 
@@ -104,27 +105,27 @@ ssh-config
 2. Convert YAML format to SSH config format:
 
 ```bash
-ssh-config -to-ssh -src input.yaml -dest output.conf
+ssh-config -lossless -to-ssh -src input.yaml -dest output.conf
 ```
 
 3. Convert SSH config format to JSON format:
 
 ```bash
-ssh-config -to-json -src ~/.ssh/config -dest output.json
+ssh-config -lossless -to-json -src ~/.ssh/config -dest output.json
 ```
 
 4. Read from standard input, output to standard output, and save in YAML format:
 
 ```bash
-cat input.conf | ssh-config -to-yaml > output.yaml
+cat input.conf | ssh-config -lossless -to-yaml > output.yaml
 ```
 
 5. Losslessly edit a configuration through the v3 YAML representation:
 
 ```bash
-ssh-config -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
 # Edit directive fields in config.v3.yaml. Unchanged lines retain their exact bytes.
-ssh-config -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 ```
 
 The previous YAML/JSON formats remain readable and are migrated to schema v3 by default. Use `-legacy` only when an existing consumer still requires the old map/array output. Repeated values and directive ordering already absent from a legacy document cannot be reconstructed.

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ SSH Config Tool is a command-line utility for managing SSH configuration files. 
 
 - Converts YAML/JSON representations into standard SSH config files
 - Converts classic SSH config files into YAML or JSON for easier editing and review
-- Scans a single file or an entire directory tree (such as `~/.ssh`) while skipping key material and other non-config files
+- Uses the lossless v3 schema by default, preserving comments, ordering, repeated directives, quoting, line endings, and unknown directives
+- Keeps the previous map-based conversion and directory scan available through `-legacy`
 - Supports reading configuration from files or standard input (stdin)
 - Supports output to files or standard output (stdout)
 - Automatically detects the input format (YAML/JSON/SSH Config) and tidies trailing blank lines
-- Offers an opt-in lossless v3 format that preserves comments, ordering, repeated directives, quoting, line endings, and unknown directives
 
 ## Installation
 
@@ -29,6 +29,12 @@ brew tap soulteary/tap
 brew install soulteary/tap/ssh-config
 ```
 
+Go users can install the v3 command directly:
+
+```bash
+go install github.com/soulteary/ssh-config/v3@latest
+```
+
 ## Usage
 
 ### Basic Usage
@@ -37,7 +43,7 @@ brew install soulteary/tap/ssh-config
 ssh-config [options]
 ```
 
-Run without arguments to export all SSH configuration under `~/.ssh` to YAML on standard output:
+Run without arguments to export `~/.ssh/config` as lossless v3 YAML on standard output:
 
 ```bash
 ssh-config
@@ -81,15 +87,15 @@ cat /ssh/test.yaml | ssh-config -to-yaml
 ### Options
 
 - `-to-yaml, -to-json, -to-ssh`: Specify output format (yaml/json/config), only one output format can be specified at a time.
-- `-src`: Specify the original configuration file or directory to read from. When omitted, the tool scans `~/.ssh`.
+- `-src`: Specify the source file. When omitted, lossless mode reads `~/.ssh/config`; legacy mode scans `~/.ssh`.
 - `-dest`: Specify the path to save the configuration file. Its parent directory must already exist. When omitted, the converted result is written to standard output.
-- `-lossless`: Use the lossless parser and v3 YAML/JSON schema. This mode accepts one source file or stdin and writes destination files atomically.
+- `-legacy`: Use the previous lossy map/array formats. This mode also enables directory scanning.
 - `-help`: View program command-line help
 - `-version`: Print release, commit, build, and tree-state metadata
 
 ### Examples
 
-1. Export the SSH configuration for your current user to YAML (default behaviour):
+1. Export the primary SSH configuration as lossless v3 YAML (default behaviour):
 
 ```bash
 ssh-config
@@ -116,14 +122,15 @@ cat input.conf | ssh-config -to-yaml > output.yaml
 5. Losslessly edit a configuration through the v3 YAML representation:
 
 ```bash
-ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+ssh-config -to-yaml -src ~/.ssh/config -dest config.v3.yaml
 # Edit directive fields in config.v3.yaml. Unchanged lines retain their exact bytes.
-ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+ssh-config -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 ```
 
-The previous YAML/JSON formats remain the default for compatibility. Lossless mode can import them and retains YAML group and host source order, but repeated values and directive ordering not represented by a legacy map cannot be reconstructed.
+The previous YAML/JSON formats remain readable and are migrated to schema v3 by default. Use `-legacy` only when an existing consumer still requires the old map/array output. Repeated values and directive ordering already absent from a legacy document cannot be reconstructed.
 
 See the [lossless schema v3 specification](./docs/lossless-schema-v3.md) for node shapes, byte-preservation rules, editing behavior, API examples, and migration limits.
+See the [v2 to v3 migration guide](./docs/migration-v3.md) before updating scripts or Go imports.
 
 ## Development
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -45,19 +45,19 @@ ssh-config [options]
 不带参数运行时，程序读取 `~/.ssh/config`，并将无损 v3 YAML 输出到标准输出：
 
 ```bash
-ssh-config
+ssh-config -lossless
 ```
 
 需要指定输入和输出文件时，请使用 `-src` 和 `-dest`：
 
 ```bash
-ssh-config -to-yaml -src input_file -dest output_file
+ssh-config -lossless -to-yaml -src input_file -dest output_file
 ```
 
 或，使用 Linux 管道来操作文件：
 
 ```bash
-cat input_file | ssh-config -to-yaml > output_file
+cat input_file | ssh-config -lossless -to-yaml > output_file
 ```
 
 ### Docker
@@ -73,20 +73,20 @@ docker pull ghcr.io/soulteary/ssh-config:latest
 将当前目录的配置文件转换并保存为新的文件：
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
+docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -lossless -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
 ```
 
 如果你只想看看转换结果：
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -to-yaml -src /ssh/test.yaml
+docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -lossless -to-yaml -src /ssh/test.yaml
 ```
 
 如果你想使用 Linux 管道来操作文件，可以先进入 Docker 交互式命令行：
 
 ```bash
 docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest bash
-cat /ssh/test.yaml | ssh-config -to-yaml
+cat /ssh/test.yaml | ssh-config -lossless -to-yaml
 ```
 
 ### 选项
@@ -95,6 +95,7 @@ cat /ssh/test.yaml | ssh-config -to-yaml
 - `-src`: 指定输入文件；省略时无损模式读取 `~/.ssh/config`，旧模式扫描 `~/.ssh`
 - `-dest`: 指定要保存的配置文件路径；父目录必须已存在，省略时将转换结果写入标准输出
 - `-legacy`: 使用原有的有损 map/array 格式，并启用目录扫描。
+- `-lossless`: 已弃用的兼容参数；v3 已默认使用无损转换。
 - `-help`: 查看程序命令行帮助
 - `-version`: 输出发布版本、提交、构建时间和工作树状态
 
@@ -103,27 +104,27 @@ cat /ssh/test.yaml | ssh-config -to-yaml
 1. 将 YAML 格式转换为 SSH 配置格式:
 
 ```bash
-ssh-config -to-ssh -src input.yaml -dest output.conf
+ssh-config -lossless -to-ssh -src input.yaml -dest output.conf
 ```
 
 2. 将 SSH 配置格式转换为 JSON 格式:
 
 ```bash
-ssh-config -to-json -src ~/.ssh/config -dest output.json
+ssh-config -lossless -to-json -src ~/.ssh/config -dest output.json
 ```
 
 3. 从标准输入读取，输出到标准输出，并以 YAML 格式保存:
 
 ```bash
-cat input.conf | ssh-config -to-yaml > output.yaml
+cat input.conf | ssh-config -lossless -to-yaml > output.yaml
 ```
 
 4. 通过 v3 YAML 格式无损编辑配置：
 
 ```bash
-ssh-config -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
 # 修改 config.v3.yaml 中的 directive 字段；未修改的行会保留原始字节。
-ssh-config -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 ```
 
 程序默认读取原有 YAML/JSON 格式并迁移为 v3 Schema。只有下游仍依赖旧 map/array 输出时才需要使用 `-legacy`；旧文档中已经丢失的重复值和指令顺序无法恢复。

--- a/README_CN.md
+++ b/README_CN.md
@@ -11,11 +11,11 @@ SSH Config Tool 是一个用于管理 SSH 配置文件的命令行工具。它�
 ## 特性
 
 - 支持从 YAML/JSON 格式转换为标准 SSH 配置格式
-- 支持从标准 SSH 配置格式转换为 YAML/JSON 格式
+- 默认使用无损 v3 格式转换，保留注释、顺序、重复指令、引号、换行符和未知指令
+- 通过 `-legacy` 保留原有 map 格式转换和目录扫描能力
 - 支持从文件输入或标准输入(stdin)读取配置
 - 支持输出到文件或标准输出(stdout)
 - 自动检测输入格式(YAML/JSON/SSH Config)
-- 提供可选的 v3 无损格式，保留注释、顺序、重复指令、引号、换行符和未知指令
 
 ## 安装
 
@@ -28,6 +28,12 @@ brew tap soulteary/tap
 brew install soulteary/tap/ssh-config
 ```
 
+Go 用户可以直接安装 v3 命令：
+
+```bash
+go install github.com/soulteary/ssh-config/v3@latest
+```
+
 ## 使用方法
 
 ### 基本用法
@@ -36,7 +42,7 @@ brew install soulteary/tap/ssh-config
 ssh-config [options]
 ```
 
-不带参数运行时，程序会扫描 `~/.ssh` 下的 SSH 配置，并将 YAML 输出到标准输出：
+不带参数运行时，程序读取 `~/.ssh/config`，并将无损 v3 YAML 输出到标准输出：
 
 ```bash
 ssh-config
@@ -59,36 +65,36 @@ cat input_file | ssh-config -to-yaml > output_file
 下载镜像
 
 ```bash
-docker pull soulteary/ssh-config:v2.0.0
+docker pull soulteary/ssh-config:latest
 # or
-docker pull ghcr.io/soulteary/ssh-config:v2.0.0
+docker pull ghcr.io/soulteary/ssh-config:latest
 ```
 
 将当前目录的配置文件转换并保存为新的文件：
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:v2.0.0 ssh-config -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
+docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
 ```
 
 如果你只想看看转换结果：
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:v2.0.0 ssh-config -to-yaml -src /ssh/test.yaml
+docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -to-yaml -src /ssh/test.yaml
 ```
 
 如果你想使用 Linux 管道来操作文件，可以先进入 Docker 交互式命令行：
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:v2.0.0 bash
+docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest bash
 cat /ssh/test.yaml | ssh-config -to-yaml
 ```
 
 ### 选项
 
 - `-to-yaml, -to-json, -to-ssh`: 指定输出格式 (yaml/json/config)，同一时间，输出格式只能指定为一种。
-- `-src`: 指定要读取的原始配置文件或配置目录；省略时扫描 `~/.ssh`
+- `-src`: 指定输入文件；省略时无损模式读取 `~/.ssh/config`，旧模式扫描 `~/.ssh`
 - `-dest`: 指定要保存的配置文件路径；父目录必须已存在，省略时将转换结果写入标准输出
-- `-lossless`: 使用无损解析器和 v3 YAML/JSON 格式。此模式接受单个源文件或标准输入，并以原子方式写入目标文件。
+- `-legacy`: 使用原有的有损 map/array 格式，并启用目录扫描。
 - `-help`: 查看程序命令行帮助
 - `-version`: 输出发布版本、提交、构建时间和工作树状态
 
@@ -115,14 +121,15 @@ cat input.conf | ssh-config -to-yaml > output.yaml
 4. 通过 v3 YAML 格式无损编辑配置：
 
 ```bash
-ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+ssh-config -to-yaml -src ~/.ssh/config -dest config.v3.yaml
 # 修改 config.v3.yaml 中的 directive 字段；未修改的行会保留原始字节。
-ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+ssh-config -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 ```
 
-为保持兼容，默认仍使用原有 YAML/JSON 格式。无损模式能够导入旧格式并保留 YAML 中 Group 和 Host 的源顺序，但无法恢复旧 map 结构未表达的重复值和指令顺序。
+程序默认读取原有 YAML/JSON 格式并迁移为 v3 Schema。只有下游仍依赖旧 map/array 输出时才需要使用 `-legacy`；旧文档中已经丢失的重复值和指令顺序无法恢复。
 
 字段结构、字节保持规则、编辑行为、Go API 示例和旧格式迁移边界详见 [v3 无损格式规范](./docs/lossless-schema-v3.md)。
+升级脚本和 Go 导入路径前，请阅读 [v2 到 v3 迁移指南](./docs/migration-v3.md)。
 
 ## 开发
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported |
 | --- | --- |
-| Current `2.x` release and `main` | Yes |
+| Current `3.x` release and `main` | Yes |
+| Latest `2.x` release | Critical security fixes only |
 | Releases before `2.0.0` | No |
 
 Schema version `3` is a data-format version, not an application major version.

--- a/docs/lossless-schema-v3.md
+++ b/docs/lossless-schema-v3.md
@@ -41,9 +41,10 @@ The root fields are:
 - `schemaVersion`: must be the integer `3`.
 - `documents`: a non-empty array of physical source documents.
 
-Each document has an optional `path` and a `nodes` array. Non-empty paths must
-be unique. An empty selector can reconstruct a document only when the envelope
-contains exactly one document.
+Each document has a `path` and a `nodes` array. The path may be empty only when
+the envelope contains one document. Every document in a multi-document
+envelope needs a non-empty, unique path. An empty selector can reconstruct a
+document only when the envelope contains exactly one document.
 
 JSON uses the same field names and shapes. Both decoders reject unknown fields,
 unsupported versions, duplicate paths, invalid Base64, trailing JSON values,
@@ -83,9 +84,9 @@ directive view.
 ## CLI workflow
 
 ```bash
-ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+ssh-config -to-yaml -src ~/.ssh/config -dest config.v3.yaml
 # Edit only directive.keyword, directive.arguments, or directive.comment.
-ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+ssh-config -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 ```
 
 Use `-to-json` instead of `-to-yaml` for a JSON envelope. Destination files are
@@ -112,11 +113,11 @@ SSH source.
 
 ## Legacy migration
 
-Lossless mode accepts the previous map-based YAML and host-array JSON formats
-and migrates them deterministically into v3. YAML group and host source order,
-including order inherited through merge aliases, is retained because SSH host
-precedence is order-sensitive. Directive map keys are sorted, and legacy
-`Default` and `Common` values use the existing precedence rules.
+The default converter accepts the previous map-based YAML and host-array JSON
+formats and migrates them deterministically into v3. YAML group and host source
+order, including order inherited through merge aliases, is retained because
+SSH host precedence is order-sensitive. Directive map keys are sorted, and
+legacy `Default` and `Common` values use the existing precedence rules.
 
 Migration cannot recover information that the legacy representation never
 stored, including repeated directive values, physical comments and

--- a/docs/lossless-schema-v3.md
+++ b/docs/lossless-schema-v3.md
@@ -2,7 +2,7 @@
 
 The v3 YAML/JSON schema is a transport and editing format for OpenSSH client
 configuration files. Its version number is independent of the application's
-semantic version and the Go module's `/v2` path.
+semantic version and the Go module's `/v3` path.
 
 ## Design guarantees
 
@@ -84,9 +84,9 @@ directive view.
 ## CLI workflow
 
 ```bash
-ssh-config -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
 # Edit only directive.keyword, directive.arguments, or directive.comment.
-ssh-config -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 ```
 
 Use `-to-json` instead of `-to-yaml` for a JSON envelope. Destination files are

--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -10,8 +10,8 @@ The default command reads one physical SSH configuration file and writes v3
 YAML:
 
 ```bash
-ssh-config -to-yaml -src ~/.ssh/config -dest config.v3.yaml
-ssh-config -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 ```
 
 Without `-src`, the default converter reads `~/.ssh/config`. It does not scan a
@@ -24,9 +24,11 @@ directory scan:
 ssh-config -legacy -to-yaml -src ~/.ssh -dest config.legacy.yaml
 ```
 
-The old `-lossless` option is no longer needed. Remove it from scripts. Legacy
-YAML and JSON remain valid inputs in the default mode and are migrated to v3;
-`-legacy` controls the output pipeline, not input compatibility.
+The old `-lossless` option is retained as a deprecated compatibility alias, so
+commands remain safe while v2 and v3 installations coexist. It is a no-op in
+v3 and can be removed after every installation has upgraded. Legacy YAML and
+JSON remain valid inputs in the default mode and are migrated to v3; `-legacy`
+controls the output pipeline, not input compatibility.
 
 ## Go module path
 

--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -1,0 +1,54 @@
+# Migrating from v2 to v3
+
+Version 3 makes the lossless schema the default CLI representation. This is a
+deliberate breaking change: YAML and JSON output now use the v3 envelope rather
+than the previous map and host-array shapes.
+
+## Command-line changes
+
+The default command reads one physical SSH configuration file and writes v3
+YAML:
+
+```bash
+ssh-config -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+ssh-config -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+```
+
+Without `-src`, the default converter reads `~/.ssh/config`. It does not scan a
+directory because joining physical files would discard their boundaries.
+
+Use `-legacy` when an existing consumer still needs the v2 representation or
+directory scan:
+
+```bash
+ssh-config -legacy -to-yaml -src ~/.ssh -dest config.legacy.yaml
+```
+
+The old `-lossless` option is no longer needed. Remove it from scripts. Legacy
+YAML and JSON remain valid inputs in the default mode and are migrated to v3;
+`-legacy` controls the output pipeline, not input compatibility.
+
+## Go module path
+
+The public module path changes with the application major version:
+
+```go
+import "github.com/soulteary/ssh-config/v3/pkg/sshconfig"
+```
+
+Update dependencies with:
+
+```bash
+go get github.com/soulteary/ssh-config/v3@latest
+go mod tidy
+```
+
+The schema's `schemaVersion: 3` is independent of the Go module and application
+version. The v3 application continues to read and write schema version 3.
+
+## Information that cannot be recovered
+
+Migrating an existing legacy document cannot recreate repeated directives,
+comments, whitespace, quoting, unknown directives, or ordering that the old
+map representation never stored. Convert from the original SSH source when an
+exact round trip matters.

--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -1,0 +1,33 @@
+# ssh-config v3.0.0
+
+Version 3 changes the default command-line representation to the lossless v3
+schema and promotes the source-preserving parser, editor, validator, Include
+resolver, and atomic writer as the public Go API.
+
+## Highlights
+
+- byte-preserving parsing and reconstruction of unchanged SSH configuration;
+- editable directive views without rewriting surrounding lines;
+- strict v3 YAML and JSON decoding with deterministic legacy migration;
+- OpenSSH argument, Include, validation, and effective-configuration tests;
+- atomic destination replacement with permission preservation and symlink
+  rejection;
+- an explicit `-legacy` option for consumers that still need the v2 formats.
+
+## Breaking changes
+
+- YAML and JSON output use schema v3 by default;
+- the no-argument source changes from the `~/.ssh` directory to
+  `~/.ssh/config`;
+- directory scanning requires `-legacy`;
+- `-lossless` is removed because lossless conversion is now the default;
+- the Go module and import paths move from `/v2` to `/v3`.
+
+See [Migrating from v2 to v3](../migration-v3.md) for command and API examples.
+
+## Verification
+
+The release candidate must pass unit tests, the race detector, vet,
+`govulncheck`, OpenSSH integration tests, a Go module consumer test, a
+GoReleaser snapshot, and container smoke checks before the final tag is
+published.


### PR DESCRIPTION
## Summary

- document lossless schema v3 as the default CLI representation
- document `-legacy`, the single-file default, and legacy input migration
- add a v2-to-v3 command and Go import migration guide
- add curated v3.0.0 release notes and breaking-change summary
- update the supported-version security policy
- clarify that multi-document schema paths must be non-empty and unique
- remove hard-coded v2 Docker examples from the Chinese README

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- reviewed together with the default-lossless and `/v3` module changes

Recommended merge order: after the default-lossless and Go module v3 PRs.