### PR TITLE
fix: preserve comment-only SSH input

### DIFF
--- a/internal/parser/lossless.go
+++ b/internal/parser/lossless.go
@@ -13,7 +13,7 @@ import (
 // routing it through the legacy map representation.
 func ProcessLossless(fileType, userInput string, args Cmd.Args) ([]byte, error) {
 	data := []byte(userInput)
-	schema, structured, err := decodeLosslessInput(fileType, data)
+	schema, structured, err := decodeLosslessInput(data)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func ProcessLossless(fileType, userInput string, args Cmd.Args) ([]byte, error) 
 	}
 }
 
-func decodeLosslessInput(fileType string, data []byte) (sshconfig.Schema, bool, error) {
+func decodeLosslessInput(data []byte) (sshconfig.Schema, bool, error) {
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 {
 		return sshconfig.Schema{}, false, nil
@@ -60,7 +60,7 @@ func decodeLosslessInput(fileType string, data []byte) (sshconfig.Schema, bool, 
 		return schema, true, err
 	}
 
-	if strings.EqualFold(fileType, "YAML") || looksLikeStructuredYAML(trimmed) {
+	if looksLikeStructuredYAML(trimmed) {
 		schema, schemaErr := sshconfig.UnmarshalSchemaYAML(data)
 		if schemaErr == nil {
 			return schema, true, nil

--- a/internal/parser/lossless_test.go
+++ b/internal/parser/lossless_test.go
@@ -41,6 +41,26 @@ func TestProcessLosslessSSHThroughStructuredFormats(t *testing.T) {
 	}
 }
 
+func TestProcessLosslessPreservesCommentOnlySSHInput(t *testing.T) {
+	t.Parallel()
+	original := []byte("# keep me\r\n# second\r\n")
+
+	// Legacy format detection classifies a comment-only document as YAML.
+	// Default lossless conversion must still prefer the original SSH bytes
+	// when the input has no v3 or legacy YAML structure markers.
+	structured, err := Parser.ProcessLossless("YAML", string(original), Cmd.Args{ToYAML: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reconstructed, err := Parser.ProcessLossless("YAML", string(structured), Cmd.Args{ToSSH: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(reconstructed, original) {
+		t.Fatalf("comment-only round trip = %q, want %q", reconstructed, original)
+	}
+}
+
 func TestProcessLosslessMigratesLegacyJSON(t *testing.T) {
 	t.Parallel()
 	input := `[{"Name":"example","Data":{"User":"root"}}]`


### PR DESCRIPTION
## Summary

- stop treating a legacy detector result of `YAML` as sufficient proof of structured input
- preserve comment-only SSH files, including CRLF bytes, through the default v3 round trip
- add a regression test for the misclassification path

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`