### PR TITLE
fix: make container CLI entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/ssh-config /usr/bin/ssh-config
 SHELL ["/bin/bash", "-c"]
-CMD ["/usr/bin/ssh-config"]
+ENTRYPOINT ["/usr/bin/ssh-config"]

--- a/README.md
+++ b/README.md
@@ -68,19 +68,19 @@ docker pull ghcr.io/soulteary/ssh-config:latest
 Convert file (test.yaml) in the current directory to YAML (abc.yaml):
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -lossless -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
+docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
 ```
 
 Just want to see the conversion results:
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -lossless -to-yaml -src /ssh/test.yaml
+docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml
 ```
 
 If you want to use Linux pipelines, you can first enter the Docker interactive command line:
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest bash
+docker run --rm -it --entrypoint bash -v `pwd`:/ssh soulteary/ssh-config:latest
 cat /ssh/test.yaml | ssh-config -lossless -to-yaml
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -73,19 +73,19 @@ docker pull ghcr.io/soulteary/ssh-config:latest
 将当前目录的配置文件转换并保存为新的文件：
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -lossless -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
+docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
 ```
 
 如果你只想看看转换结果：
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest ssh-config -lossless -to-yaml -src /ssh/test.yaml
+docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml
 ```
 
 如果你想使用 Linux 管道来操作文件，可以先进入 Docker 交互式命令行：
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest bash
+docker run --rm -it --entrypoint bash -v `pwd`:/ssh soulteary/ssh-config:latest
 cat /ssh/test.yaml | ssh-config -lossless -to-yaml
 ```
 


### PR DESCRIPTION
## Summary

- make the packaged binary the container `ENTRYPOINT`, so release smoke-test arguments reach `ssh-config`
- update English and Chinese Docker examples for the entrypoint behavior
- retain an interactive shell example through `--entrypoint bash`

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

The release workflow's existing container smoke test will exercise this behavior on the published image.