### PR TITLE
fix: validate schema documents before reconstruction

### DIFF
--- a/pkg/sshconfig/schema.go
+++ b/pkg/sshconfig/schema.go
@@ -99,11 +99,11 @@ func (s Schema) Document(path string) (*Document, error) {
 		if len(s.Documents) != 1 {
 			return nil, fmt.Errorf("sshconfig: an empty document path requires exactly one schema document")
 		}
-		return s.Documents[0].Document()
+		return s.Documents[0].document()
 	}
 	for _, document := range s.Documents {
 		if document.Path == path {
-			return document.Document()
+			return document.document()
 		}
 	}
 	return nil, fmt.Errorf("sshconfig: schema document %q not found", path)
@@ -111,6 +111,13 @@ func (s Schema) Document(path string) (*Document, error) {
 
 // Document reconstructs a lossless syntax document from a v3 document.
 func (s SchemaDocument) Document() (*Document, error) {
+	if err := NewSchema(s).Validate(); err != nil {
+		return nil, err
+	}
+	return s.document()
+}
+
+func (s SchemaDocument) document() (*Document, error) {
 	var output bytes.Buffer
 	for index, node := range s.Nodes {
 		raw, err := decodeSchemaRaw(node.RawBase64)

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -180,6 +180,25 @@ func TestSchemaNewDirectiveDefaultsToLF(t *testing.T) {
 	}
 }
 
+func TestSchemaDocumentRejectsInvalidNodeShapes(t *testing.T) {
+	t.Parallel()
+	tests := []SchemaDocument{
+		{Nodes: []SchemaNode{{
+			Type:      "comment",
+			Directive: &SchemaDirective{Keyword: "Host", Arguments: []string{"example"}},
+		}}},
+		{Nodes: []SchemaNode{{
+			Type:      "directive",
+			Directive: &SchemaDirective{Keyword: "Host\nProxyCommand", Arguments: []string{"example"}},
+		}}},
+	}
+	for _, schemaDocument := range tests {
+		if _, err := schemaDocument.Document(); err == nil {
+			t.Fatalf("SchemaDocument.Document() accepted invalid document: %#v", schemaDocument)
+		}
+	}
+}
+
 func TestSchemaValidationRejectsRawNodeShapeMismatches(t *testing.T) {
 	t.Parallel()
 	encode := func(raw string) string {


### PR DESCRIPTION
## Summary

- validate a standalone `SchemaDocument` before reconstructing SSH bytes
- keep `Schema.Document` on a single validation pass through a private reconstruction helper
- reject invalid node shapes and cross-line directive fields through the public document API

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`