### PR TITLE
fix: render new blank schema nodes

### DIFF
--- a/pkg/sshconfig/schema.go
+++ b/pkg/sshconfig/schema.go
@@ -118,7 +118,11 @@ func (s SchemaDocument) Document() (*Document, error) {
 			return nil, fmt.Errorf("sshconfig: schema node %d: %w", index, err)
 		}
 		if node.Directive == nil {
-			if len(raw) == 0 && node.Type != "blank" {
+			if len(raw) == 0 {
+				if node.Type == "blank" {
+					output.WriteByte('\n')
+					continue
+				}
 				return nil, fmt.Errorf("sshconfig: schema node %d has neither raw bytes nor a directive", index)
 			}
 			output.Write(raw)

--- a/pkg/sshconfig/schema_blank_test.go
+++ b/pkg/sshconfig/schema_blank_test.go
@@ -1,0 +1,25 @@
+package sshconfig
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSchemaNewBlankDefaultsToLF(t *testing.T) {
+	t.Parallel()
+	schema := NewSchema(SchemaDocument{Nodes: []SchemaNode{
+		{Type: "blank"},
+		{Type: "blank"},
+	}})
+	doc, err := schema.Document("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := doc.MarshalPreserve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []byte("\n\n"); !bytes.Equal(got, want) {
+		t.Fatalf("new blank nodes = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- render v3 blank nodes without `rawBase64` as a single LF line
- preserve existing raw bytes when a parsed blank node already carries them
- add an isolated regression test so this PR merges cleanly with the schema-validation hardening

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`