### PR TITLE
fix: reject duplicate v3 JSON fields

### DIFF
--- a/pkg/sshconfig/schema.go
+++ b/pkg/sshconfig/schema.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"fmt"
 	"io"
 	"slices"
@@ -214,13 +215,8 @@ func MarshalSchemaJSON(schema Schema) ([]byte, error) {
 // UnmarshalSchemaJSON strictly decodes one JSON schema document.
 func UnmarshalSchemaJSON(data []byte) (Schema, error) {
 	var schema Schema
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&schema); err != nil {
+	if err := jsonv2.Unmarshal(data, &schema, jsonv2.RejectUnknownMembers(true)); err != nil {
 		return Schema{}, fmt.Errorf("sshconfig: decode v3 JSON: %w", err)
-	}
-	if err := ensureJSONEOF(decoder); err != nil {
-		return Schema{}, err
 	}
 	if err := schema.Validate(); err != nil {
 		return Schema{}, err

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -215,6 +215,15 @@ func TestSchemaStrictValidation(t *testing.T) {
 	if _, err := UnmarshalSchemaYAML([]byte("schemaVersion: 3\ndocuments: []\nextra: true\n")); err == nil {
 		t.Fatal("YAML accepted an unknown field")
 	}
+	duplicateJSON := []string{
+		`{"schemaVersion":2,"schemaVersion":3,"documents":[{"nodes":[]}]}`,
+		`{"schemaVersion":3,"documents":[{"nodes":[{"type":"directive","directive":{"keyword":"ProxyCommand","keyword":"Host","arguments":["safe"]}}]}]}`,
+	}
+	for _, input := range duplicateJSON {
+		if _, err := UnmarshalSchemaJSON([]byte(input)); err == nil {
+			t.Fatalf("JSON accepted duplicate fields: %s", input)
+		}
+	}
 	badVersion := Schema{SchemaVersion: 2, Documents: []SchemaDocument{{}}}
 	if err := badVersion.Validate(); err == nil {
 		t.Fatal("schema accepted an old version")


### PR DESCRIPTION
## Summary

- decode v3 JSON with `encoding/json/v2` strict member handling
- reject unknown members and duplicate object names instead of silently accepting the last value
- cover duplicate envelope fields and duplicate nested directive fields

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`