### PR TITLE
fix: avoid HOME lookup for piped input

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,19 @@ func Run(args Cmd.Args, deps Dependencies) error {
 	}
 
 	pipeMode := deps.CheckUseStdin()
+	if !pipeMode && args.Src == "" {
+		if deps.UserHomeDir == nil {
+			err := fmt.Errorf("user home directory lookup is unavailable")
+			deps.errorln("Error: getting user home directory:", err)
+			return err
+		}
+		homeDir, err := deps.UserHomeDir()
+		if err != nil {
+			deps.errorln("Error: getting user home directory:", err)
+			return err
+		}
+		args.Src = defaultSource(homeDir, args.Legacy)
+	}
 	var userInput string
 	if pipeMode {
 		if deps.ReadStdin != nil {
@@ -175,6 +188,7 @@ func MainWithDependencies(exit func(int), userHomeDir func() (string, error)) {
 		},
 		Process:       Parser.Process,
 		CheckUseStdin: func() bool { return Cmd.CheckUseStdin(os.Stdin.Stat) },
+		UserHomeDir:   userHomeDir,
 	}
 	args := Cmd.ParseArgs()
 	if args.ShowHelp {
@@ -184,18 +198,6 @@ func MainWithDependencies(exit func(int), userHomeDir func() (string, error)) {
 	if args.Version {
 		fmt.Print(versionText())
 		return
-	}
-
-	// Lossless conversion works on one physical file so source bytes and file
-	// boundaries remain unambiguous. Legacy mode retains the v2 directory scan.
-	if args.Src == "" {
-		homeDir, err := userHomeDir()
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "Error: getting user home directory:", err)
-			exit(1)
-			return
-		}
-		args.Src = defaultSource(homeDir, args.Legacy)
 	}
 
 	// default to YAML when no conversion flag is provided

--- a/main_test.go
+++ b/main_test.go
@@ -240,6 +240,26 @@ func TestRunDefaultPipePreservesInputAndOutputBytes(t *testing.T) {
 	}
 }
 
+func TestRunPipeDoesNotRequireHomeDirectory(t *testing.T) {
+	input := []byte("Host example\n")
+	err := Run(Cmd.Args{ToYAML: true}, Dependencies{
+		Println:       func(...interface{}) (int, error) { return 0, nil },
+		CheckUseStdin: func() bool { return true },
+		ReadStdin:     func() ([]byte, error) { return input, nil },
+		UserHomeDir: func() (string, error) {
+			t.Fatal("piped input queried the user home directory")
+			return "", errors.New("unreachable")
+		},
+		Process: func(_ string, got string, _ Cmd.Args) ([]byte, error) {
+			return []byte(got), nil
+		},
+		WriteOutput: func([]byte) error { return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRunDefaultModeReadsItsStructuredOutput(t *testing.T) {
 	original := []byte("Host=example\r\nIdentityFile first\r\nIdentityFile second")
 	formats := []struct {


### PR DESCRIPTION
## Summary

- defer the default source-path lookup until `Run` knows input is not coming from stdin
- allow piped conversions to work when the current user has no resolvable home directory
- retain mode-specific defaults for non-piped invocations

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`