### PR TITLE
docs: clarify lossless trailing-line behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SSH Config Tool is a command-line utility for managing SSH configuration files. 
 - Keeps the previous map-based conversion and directory scan available through `-legacy`
 - Supports reading configuration from files or standard input (stdin)
 - Supports output to files or standard output (stdout)
-- Automatically detects the input format (YAML/JSON/SSH Config) and tidies trailing blank lines
+- Automatically detects the input format (YAML/JSON/SSH Config); the default mode preserves the underlying SSH document bytes, while only `-legacy` normalizes trailing blank lines
 
 ## Installation
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -15,7 +15,7 @@ SSH Config Tool 是一个用于管理 SSH 配置文件的命令行工具。它�
 - 通过 `-legacy` 保留原有 map 格式转换和目录扫描能力
 - 支持从文件输入或标准输入(stdin)读取配置
 - 支持输出到文件或标准输出(stdout)
-- 自动检测输入格式(YAML/JSON/SSH Config)
+- 自动检测输入格式(YAML/JSON/SSH Config)；默认无损模式保留底层 SSH 文档字节，仅 `-legacy` 会整理末尾空行
 
 ## 安装
 


### PR DESCRIPTION
## Summary

- clarify that the default v3 pipeline preserves trailing bytes
- document that trailing blank-line normalization only applies to `-legacy`
- keep the English and Chinese feature lists aligned

## Verification

- `git diff --check`

This is a documentation-only change.