### PR TITLE
release: use curated v3 release notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,12 +94,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Select release notes
+        id: release-notes
+        if: success() && startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: |
+          notes="docs/releases/${GITHUB_REF_NAME}.md"
+          if [[ -f "${notes}" ]]; then
+            printf 'args=release --clean --release-notes %s\n' "${notes}" >> "${GITHUB_OUTPUT}"
+          else
+            printf 'args=release --clean\n' >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Publish release
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         if: success() && startsWith(github.ref, 'refs/tags/')
         with:
           version: v2.18.0
-          args: release --clean
+          args: ${{ steps.release-notes.outputs.args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -20,7 +20,8 @@ resolver, and atomic writer as the public Go API.
 - the no-argument source changes from the `~/.ssh` directory to
   `~/.ssh/config`;
 - directory scanning requires `-legacy`;
-- `-lossless` is removed because lossless conversion is now the default;
+- `-lossless` remains as a deprecated no-op compatibility alias while
+  lossless conversion becomes the default;
 - the Go module and import paths move from `/v2` to `/v3`.
 
 See [Migrating from v2 to v3](../migration-v3.md) for command and API examples.
@@ -31,3 +32,6 @@ The release candidate must pass unit tests, the race detector, vet,
 `govulncheck`, OpenSSH integration tests, a Go module consumer test, a
 GoReleaser snapshot, and container smoke checks before the final tag is
 published.
+
+This document is also used as the curated GitHub Release body. The full commit
+comparison remains available through the link appended by GoReleaser.


### PR DESCRIPTION
## Summary

- publish `docs/releases/v3.0.0.md` as the curated GitHub Release body
- correct the v3 notes to describe `-lossless` as a deprecated no-op alias
- retain GoReleaser's full comparison footer

## Verification

- `go test ./...`
- `go vet ./...`
- `goreleaser check`
- `git diff --check`