### PR TITLE
ci: serialize v3 release runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,16 @@ on:
 
 permissions:
   contents: write
-  id-token: write
   packages: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -71,14 +75,14 @@ jobs:
           args: check
 
       - name: Login to Docker Hub
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
@@ -96,7 +100,7 @@ jobs:
 
       - name: Publish release
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
-        if: success() && startsWith(github.ref, 'refs/tags/')
+        if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         with:
           version: v2.18.0
           args: release --clean
@@ -104,5 +108,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Smoke-test published container
-        if: success() && startsWith(github.ref, 'refs/tags/')
+        if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         run: docker run --rm "ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_REF_NAME}" -version


### PR DESCRIPTION
## Summary

- serialize release runs by ref without cancelling an active publisher
- restrict registry logins, publishing, and published-image smoke tests to tag push events
- keep manual dispatches snapshot-only
- remove unused OIDC permission and bound the job with a 45-minute timeout

## Verification

- parsed `.github/workflows/build.yml` as YAML and asserted release guards
- `git diff --check`
- verified this change merges cleanly with the curated release-notes PR