### PR TITLE
fix: detect custom legacy YAML groups

### DIFF
--- a/internal/parser/lossless.go
+++ b/internal/parser/lossless.go
@@ -13,7 +13,7 @@ import (
 // routing it through the legacy map representation.
 func ProcessLossless(fileType, userInput string, args Cmd.Args) ([]byte, error) {
 	data := []byte(userInput)
-	schema, structured, err := decodeLosslessInput(data)
+	schema, structured, err := decodeLosslessInput(fileType, data)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func ProcessLossless(fileType, userInput string, args Cmd.Args) ([]byte, error) 
 	}
 }
 
-func decodeLosslessInput(data []byte) (sshconfig.Schema, bool, error) {
+func decodeLosslessInput(fileType string, data []byte) (sshconfig.Schema, bool, error) {
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 {
 		return sshconfig.Schema{}, false, nil
@@ -60,7 +60,7 @@ func decodeLosslessInput(data []byte) (sshconfig.Schema, bool, error) {
 		return schema, true, err
 	}
 
-	if looksLikeStructuredYAML(trimmed) {
+	if looksLikeStructuredYAML(trimmed) || strings.EqualFold(fileType, "YAML") && hasYAMLContent(trimmed) {
 		schema, schemaErr := sshconfig.UnmarshalSchemaYAML(data)
 		if schemaErr == nil {
 			return schema, true, nil
@@ -73,6 +73,16 @@ func decodeLosslessInput(data []byte) (sshconfig.Schema, bool, error) {
 	}
 
 	return sshconfig.Schema{}, false, nil
+}
+
+func hasYAMLContent(data []byte) bool {
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && line != "---" && line != "..." && !strings.HasPrefix(line, "#") {
+			return true
+		}
+	}
+	return false
 }
 
 func looksLikeStructuredYAML(data []byte) bool {

--- a/internal/parser/lossless_test.go
+++ b/internal/parser/lossless_test.go
@@ -61,6 +61,26 @@ func TestProcessLosslessPreservesCommentOnlySSHInput(t *testing.T) {
 	}
 }
 
+func TestProcessLosslessMigratesCustomLegacyYAMLGroup(t *testing.T) {
+	t.Parallel()
+	input := `work:
+  Hosts:
+    example:
+      config:
+        User: alice
+`
+
+	got, err := Parser.ProcessLossless("YAML", input, Cmd.Args{ToSSH: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Host example", "User alice"} {
+		if !bytes.Contains(got, []byte(want)) {
+			t.Fatalf("migrated SSH = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
 func TestProcessLosslessMigratesLegacyJSON(t *testing.T) {
 	t.Parallel()
 	input := `[{"Name":"example","Data":{"User":"root"}}]`


### PR DESCRIPTION
## Summary

- retain detected YAML as a fallback for non-comment content
- keep comment-only SSH input on the raw lossless path
- restore migration of legacy YAML with arbitrary inline group names

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

Follow-up to #57 and its review finding.