### PR TITLE
fix: preserve appended blank lines

### DIFF
--- a/pkg/sshconfig/schema.go
+++ b/pkg/sshconfig/schema.go
@@ -128,7 +128,7 @@ func (s SchemaDocument) document() (*Document, error) {
 		if node.Directive == nil {
 			if len(raw) == 0 {
 				if node.Type == "blank" {
-					output.WriteByte('\n')
+					writeSchemaBlank(&output)
 					continue
 				}
 				return nil, fmt.Errorf("sshconfig: schema node %d has neither raw bytes nor a directive", index)
@@ -143,6 +143,22 @@ func (s SchemaDocument) document() (*Document, error) {
 		output.Write(renderSchemaDirective(node.Directive, detectLineEnding(raw), len(raw) == 0))
 	}
 	return Parse(output.Bytes())
+}
+
+func writeSchemaBlank(output *bytes.Buffer) {
+	current := output.Bytes()
+	switch {
+	case len(current) == 0:
+		output.WriteByte('\n')
+	case bytes.HasSuffix(current, []byte("\r\n")):
+		output.WriteString("\r\n")
+	case bytes.HasSuffix(current, []byte("\n")):
+		output.WriteByte('\n')
+	case bytes.HasSuffix(current, []byte("\r")):
+		output.WriteByte('\r')
+	default:
+		output.WriteString("\n\n")
+	}
 }
 
 // Validate checks the v3 envelope and node shapes.

--- a/pkg/sshconfig/schema_blank_test.go
+++ b/pkg/sshconfig/schema_blank_test.go
@@ -23,3 +23,38 @@ func TestSchemaNewBlankDefaultsToLF(t *testing.T) {
 		t.Fatalf("new blank nodes = %q, want %q", got, want)
 	}
 }
+
+func TestSchemaAppendedBlankRemainsAPhysicalLine(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input []byte
+		want  []byte
+	}{
+		{input: []byte("Host example"), want: []byte("Host example\n\n")},
+		{input: []byte("Host example\n"), want: []byte("Host example\n\n")},
+		{input: []byte("Host example\r\n"), want: []byte("Host example\r\n\r\n")},
+		{input: []byte("Host example\r"), want: []byte("Host example\r\r")},
+	}
+	for _, test := range tests {
+		doc, err := Parse(test.input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		schemaDocument, err := doc.ToSchema("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		schemaDocument.Nodes = append(schemaDocument.Nodes, SchemaNode{Type: "blank"})
+		reconstructed, err := NewSchema(schemaDocument).Document("")
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := reconstructed.MarshalPreserve()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, test.want) {
+			t.Fatalf("appended blank = %q, want %q", got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- ensure a new blank schema node remains a distinct physical line after an unterminated directive
- preserve LF, CRLF, and CR line-ending style when the preceding node is already terminated
- add reconstruction coverage for all four boundary cases

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

Follow-up to #60 and its review finding.