### PR TITLE
ci: serialize all publishing tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,8 @@ permissions:
   packages: write
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-publish
+  queue: max
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

- place every release workflow run in one non-cancelling concurrency group
- prevent two stable tags from racing to publish the shared `latest` container tag
- keep the existing tag-push guards and snapshot-only manual behavior

## Verification

- parsed `.github/workflows/build.yml` as YAML
- asserted the global concurrency group and non-cancelling policy
- `git diff --check`

Follow-up to #65 and its review finding.