### PR TITLE
fix: identify legacy YAML structure

### DIFF
--- a/internal/parser/lossless.go
+++ b/internal/parser/lossless.go
@@ -7,6 +7,7 @@ import (
 
 	Cmd "github.com/soulteary/ssh-config/v3/cmd"
 	"github.com/soulteary/ssh-config/v3/pkg/sshconfig"
+	"gopkg.in/yaml.v3"
 )
 
 // ProcessLossless converts SSH source or a v3 structured document without
@@ -60,7 +61,7 @@ func decodeLosslessInput(fileType string, data []byte) (sshconfig.Schema, bool, 
 		return schema, true, err
 	}
 
-	if looksLikeStructuredYAML(trimmed) || strings.EqualFold(fileType, "YAML") && hasYAMLContent(trimmed) {
+	if looksLikeStructuredYAML(trimmed) || strings.EqualFold(fileType, "YAML") && hasLegacyYAMLStructure(trimmed) {
 		schema, schemaErr := sshconfig.UnmarshalSchemaYAML(data)
 		if schemaErr == nil {
 			return schema, true, nil
@@ -75,11 +76,27 @@ func decodeLosslessInput(fileType string, data []byte) (sshconfig.Schema, bool, 
 	return sshconfig.Schema{}, false, nil
 }
 
-func hasYAMLContent(data []byte) bool {
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line != "" && line != "---" && line != "..." && !strings.HasPrefix(line, "#") {
-			return true
+func hasLegacyYAMLStructure(data []byte) bool {
+	var document yaml.Node
+	if err := yaml.Unmarshal(data, &document); err != nil || len(document.Content) == 0 {
+		return false
+	}
+	root := document.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return false
+	}
+	for index := 0; index+1 < len(root.Content); index += 2 {
+		group := root.Content[index+1]
+		if group.Kind == yaml.AliasNode {
+			group = group.Alias
+		}
+		if group == nil || group.Kind != yaml.MappingNode {
+			continue
+		}
+		for field := 0; field+1 < len(group.Content); field += 2 {
+			if group.Content[field].Value == "Hosts" {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/parser/lossless_test.go
+++ b/internal/parser/lossless_test.go
@@ -81,6 +81,19 @@ func TestProcessLosslessMigratesCustomLegacyYAMLGroup(t *testing.T) {
 	}
 }
 
+func TestProcessLosslessPreservesSSHThatLooksLikeYAML(t *testing.T) {
+	t.Parallel()
+	input := []byte("RemoteCommand echo foo: {}\n")
+
+	got, err := Parser.ProcessLossless("YAML", string(input), Cmd.Args{ToSSH: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, input) {
+		t.Fatalf("YAML-like SSH = %q, want %q", got, input)
+	}
+}
+
 func TestProcessLosslessMigratesLegacyJSON(t *testing.T) {
 	t.Parallel()
 	input := `[{"Name":"example","Data":{"User":"root"}}]`


### PR DESCRIPTION
## Summary

- require a nested legacy `Hosts` field before using detected YAML as the migration fallback
- continue supporting arbitrary legacy group names
- preserve valid SSH directives such as `RemoteCommand echo foo: {}` even when generic detection labels them YAML

## Verification

- `go mod tidy -diff`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

Follow-up to #66 and its review finding.