### PR TITLE
fix: reject duplicate legacy JSON fields

### DIFF
--- a/internal/fn/decode_strict_test.go
+++ b/internal/fn/decode_strict_test.go
@@ -28,9 +28,12 @@ func TestGetYamlDataStrictRejectsUnknownAndDuplicateFields(t *testing.T) {
 func TestGetJSONDataStrictRejectsUnknownAndTrailingValues(t *testing.T) {
 	t.Parallel()
 	tests := map[string]string{
-		"unknown field":  `[{"Name":"example","Datta":{"User":"alice"}}]`,
-		"second value":   `[] []`,
-		"trailing token": `[] invalid`,
+		"unknown field":         `[{"Name":"example","Datta":{"User":"alice"}}]`,
+		"duplicate host field":  `[{"Name":"safe","Name":"evil","Data":{"User":"alice"}}]`,
+		"case folded duplicate": `[{"Name":"safe","name":"evil","Data":{"User":"alice"}}]`,
+		"duplicate data field":  `[{"Name":"example","Data":{"User":"alice","User":"root"}}]`,
+		"second value":          `[] []`,
+		"trailing token":        `[] invalid`,
 	}
 	for name, input := range tests {
 		name, input := name, input
@@ -66,5 +69,8 @@ func TestStrictLegacyDecodersKeepValidInput(t *testing.T) {
 	}
 	if _, err := Fn.GetJSONDataStrict("  [{\"Name\":\"example\",\"Data\":{\"User\":\"alice\"}}]\n"); err != nil {
 		t.Fatalf("GetJSONDataStrict() error = %v", err)
+	}
+	if _, err := Fn.GetJSONDataStrict("  [{\"name\":\"example\",\"data\":{\"User\":\"alice\"}}]\n"); err != nil {
+		t.Fatalf("GetJSONDataStrict() lowercase compatibility error = %v", err)
 	}
 }

--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -18,6 +18,7 @@ package fn
 
 import (
 	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"fmt"
 	"io"
 	"os"
@@ -115,21 +116,11 @@ func GetJSONData(input string) (jsonConfig []Define.HostConfigForJSON) {
 // GetJSONDataStrict decodes exactly one legacy JSON document and rejects
 // unknown fields.
 func GetJSONDataStrict(input string) (jsonConfig []Define.HostConfigForJSON, err error) {
-	decoder := json.NewDecoder(strings.NewReader(input))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&jsonConfig); err != nil {
-		return jsonConfig, err
-	}
-
-	var trailing json.RawMessage
-	switch err := decoder.Decode(&trailing); err {
-	case io.EOF:
-		return jsonConfig, nil
-	case nil:
-		return jsonConfig, fmt.Errorf("unexpected JSON value after document")
-	default:
-		return jsonConfig, fmt.Errorf("invalid trailing JSON data: %w", err)
-	}
+	err = jsonv2.Unmarshal([]byte(input), &jsonConfig,
+		jsonv2.RejectUnknownMembers(true),
+		jsonv2.MatchCaseInsensitiveNames(true),
+	)
+	return jsonConfig, err
 }
 
 func DetectStringType(input string) string {

--- a/pkg/sshconfig/migrate.go
+++ b/pkg/sshconfig/migrate.go
@@ -2,7 +2,7 @@ package sshconfig
 
 import (
 	"bytes"
-	"encoding/json"
+	jsonv2 "encoding/json/v2"
 	"fmt"
 	"sort"
 	"strings"
@@ -138,13 +138,11 @@ func orderedLegacyMapKeys[V any](preferred []string, values map[string]V) []stri
 // MigrateLegacyJSON converts the previous host-array JSON format into v3.
 func MigrateLegacyJSON(data []byte, path string) (Schema, error) {
 	var hosts []legacyHost
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&hosts); err != nil {
+	if err := jsonv2.Unmarshal(data, &hosts,
+		jsonv2.RejectUnknownMembers(true),
+		jsonv2.MatchCaseInsensitiveNames(true),
+	); err != nil {
 		return Schema{}, fmt.Errorf("sshconfig: decode legacy JSON: %w", err)
-	}
-	if err := ensureJSONEOF(decoder); err != nil {
-		return Schema{}, err
 	}
 	var output bytes.Buffer
 	for _, host := range hosts {

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -398,6 +398,24 @@ func TestMigrateLegacyFormatsRejectCrossLineFields(t *testing.T) {
 	}
 }
 
+func TestMigrateLegacyJSONRejectsDuplicateFields(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"host name":        `[{"Name":"safe","Name":"evil","Data":{"User":"alice"}}]`,
+		"case folded name": `[{"Name":"safe","name":"evil","Data":{"User":"alice"}}]`,
+		"directive":        `[{"Name":"example","Data":{"User":"alice","User":"root"}}]`,
+	}
+	for name, input := range tests {
+		name, input := name, input
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := MigrateLegacyJSON([]byte(input), "config"); err == nil {
+				t.Fatal("MigrateLegacyJSON() accepted duplicate fields")
+			}
+		})
+	}
+}
+
 func TestMigrateLegacyYAMLAllowsMergeOverrides(t *testing.T) {
 	t.Parallel()
 	inputs := []string{


### PR DESCRIPTION
## Summary

- move both legacy JSON decoders to the standard JSON v2 implementation
- reject duplicate object members, including case-folded struct fields and nested directive maps
- retain legacy case-insensitive field-name compatibility
- continue rejecting unknown members and trailing JSON values

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- regression coverage for host and nested `Data` duplicates

This prevents silent security-sensitive overrides during v2-to-v3 migration and in `-legacy` mode.