### PR TITLE
fix: classify structured input by document shape

### DIFF
--- a/internal/parser/lossless.go
+++ b/internal/parser/lossless.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -47,21 +48,27 @@ func ProcessLossless(fileType, userInput string, args Cmd.Args) ([]byte, error) 
 }
 
 func decodeLosslessInput(fileType string, data []byte) (sshconfig.Schema, bool, error) {
+	_ = fileType // Classification is based on the parsed document shape, not its filename.
 	trimmed := bytes.TrimSpace(data)
 	if len(trimmed) == 0 {
 		return sshconfig.Schema{}, false, nil
 	}
 
-	switch trimmed[0] {
-	case '{':
-		schema, err := sshconfig.UnmarshalSchemaJSON(data)
-		return schema, true, err
-	case '[':
+	switch classifyStructuredInput(trimmed) {
+	case structuredLegacyJSON:
 		schema, err := sshconfig.MigrateLegacyJSON(data, "")
 		return schema, true, err
-	}
-
-	if looksLikeStructuredYAML(trimmed) || strings.EqualFold(fileType, "YAML") && hasLegacyYAMLStructure(trimmed) {
+	case structuredV3:
+		if json.Valid(trimmed) {
+			schema, err := sshconfig.UnmarshalSchemaJSON(data)
+			return schema, true, err
+		}
+		schema, err := sshconfig.UnmarshalSchemaYAML(data)
+		return schema, true, err
+	case structuredLegacyYAML:
+		schema, err := sshconfig.MigrateLegacyYAML(data, "")
+		return schema, true, err
+	case structuredYAMLUnknown:
 		schema, schemaErr := sshconfig.UnmarshalSchemaYAML(data)
 		if schemaErr == nil {
 			return schema, true, nil
@@ -76,46 +83,140 @@ func decodeLosslessInput(fileType string, data []byte) (sshconfig.Schema, bool, 
 	return sshconfig.Schema{}, false, nil
 }
 
-func hasLegacyYAMLStructure(data []byte) bool {
+type structuredInputKind uint8
+
+const (
+	structuredRaw structuredInputKind = iota
+	structuredV3
+	structuredLegacyJSON
+	structuredLegacyYAML
+	structuredYAMLUnknown
+)
+
+func classifyStructuredInput(data []byte) structuredInputKind {
+	if len(data) == 0 {
+		return structuredRaw
+	}
+	if data[0] == '[' {
+		return structuredLegacyJSON
+	}
+	// A known OpenSSH directive at the start of a document is authoritative.
+	// In particular, IgnoreUnknown may deliberately permit later lines whose
+	// text happens to look like a v3 or legacy YAML field.
+	if startsWithKnownSSHDirective(data) {
+		return structuredRaw
+	}
+
 	var document yaml.Node
 	if err := yaml.Unmarshal(data, &document); err != nil || len(document.Content) == 0 {
-		return false
+		return structuredKindFromFirstLine(data)
 	}
 	root := document.Content[0]
-	if root.Kind != yaml.MappingNode {
-		return false
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		root = root.Content[0]
 	}
+	for root != nil && root.Kind == yaml.AliasNode {
+		root = root.Alias
+	}
+	if root == nil {
+		return structuredRaw
+	}
+	if root.Kind != yaml.MappingNode {
+		return structuredRaw
+	}
+
+	var hasV3, hasLegacy bool
 	for index := 0; index+1 < len(root.Content); index += 2 {
-		group := root.Content[index+1]
-		if group.Kind == yaml.AliasNode {
-			group = group.Alias
-		}
-		if group == nil || group.Kind != yaml.MappingNode {
+		key := root.Content[index]
+		if key.Kind != yaml.ScalarNode {
 			continue
 		}
-		for field := 0; field+1 < len(group.Content); field += 2 {
-			if group.Content[field].Value == "Hosts" {
-				return true
+		switch strings.ToLower(key.Value) {
+		case "schemaversion", "documents":
+			hasV3 = true
+		case "global", "default":
+			hasLegacy = true
+		default:
+			if strings.HasPrefix(strings.ToLower(key.Value), "group ") || mappingHasKey(root.Content[index+1], "Hosts") {
+				hasLegacy = true
 			}
+		}
+	}
+	if hasV3 {
+		return structuredV3
+	}
+	if hasLegacy {
+		return structuredLegacyYAML
+	}
+	return structuredRaw
+}
+
+func mappingHasKey(node *yaml.Node, name string) bool {
+	for node != nil && node.Kind == yaml.AliasNode {
+		node = node.Alias
+	}
+	if node == nil || node.Kind != yaml.MappingNode {
+		return false
+	}
+	for index := 0; index+1 < len(node.Content); index += 2 {
+		if node.Content[index].Kind == yaml.ScalarNode && strings.EqualFold(node.Content[index].Value, name) {
+			return true
 		}
 	}
 	return false
 }
 
-func looksLikeStructuredYAML(data []byte) bool {
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || line == "---" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		lower := strings.ToLower(line)
-		if strings.HasPrefix(lower, "schemaversion:") ||
-			strings.HasPrefix(lower, "documents:") ||
-			strings.HasPrefix(lower, "global:") ||
-			strings.HasPrefix(lower, "default:") ||
-			(strings.HasPrefix(lower, "group ") && strings.Contains(line, ":")) {
-			return true
+func startsWithKnownSSHDirective(data []byte) bool {
+	line := firstContentLine(data)
+	if len(line) == 0 {
+		return false
+	}
+	document, err := sshconfig.Parse(append(bytes.Clone(line), '\n'))
+	if err != nil {
+		return false
+	}
+	nodes := document.Nodes()
+	if len(nodes) != 1 || nodes[0].Directive == nil {
+		return false
+	}
+	_, known := sshconfig.LookupKeyword(nodes[0].Directive.KeywordValue)
+	return known
+}
+
+func structuredKindFromFirstLine(data []byte) structuredInputKind {
+	line := strings.TrimSpace(string(firstContentLine(data)))
+	if line == "" {
+		return structuredRaw
+	}
+	if strings.HasPrefix(line, "{") {
+		return structuredYAMLUnknown
+	}
+	colon := strings.IndexByte(line, ':')
+	if colon < 0 {
+		return structuredRaw
+	}
+	key := strings.TrimSpace(line[:colon])
+	key = strings.Trim(key, "\"'")
+	switch strings.ToLower(key) {
+	case "schemaversion", "documents":
+		return structuredV3
+	case "global", "default":
+		return structuredLegacyYAML
+	default:
+		if strings.HasPrefix(strings.ToLower(key), "group ") {
+			return structuredLegacyYAML
 		}
 	}
-	return false
+	return structuredRaw
+}
+
+func firstContentLine(data []byte) []byte {
+	for _, line := range bytes.Split(data, []byte{'\n'}) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 || bytes.HasPrefix(line, []byte("#")) || bytes.Equal(line, []byte("---")) || bytes.HasPrefix(line, []byte("%YAML")) {
+			continue
+		}
+		return line
+	}
+	return nil
 }

--- a/internal/parser/lossless_test.go
+++ b/internal/parser/lossless_test.go
@@ -134,3 +134,78 @@ schemaVersion: 3
 		t.Fatalf("reordered v3 YAML output = %q", got)
 	}
 }
+
+func TestProcessLosslessPreservesIgnoreUnknownMarkerCollisions(t *testing.T) {
+	t.Parallel()
+	input := "IgnoreUnknown schemaVersion:,documents:,global:,default:\n" +
+		"schemaVersion: 3\n" +
+		"documents: keep\n" +
+		"global: keep\n" +
+		"default: keep\n" +
+		"Host *\n    User audit\n"
+
+	got, err := Parser.ProcessLossless("YAML", input, Cmd.Args{ToSSH: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != input {
+		t.Fatalf("marker-bearing SSH = %q, want %q", got, input)
+	}
+}
+
+func TestProcessLosslessAcceptsFlowAndQuotedYAML(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "flow legacy",
+			input: `{global: {User: alice}}`,
+			want:  "Host *\n    User alice\n",
+		},
+		{
+			name:  "JSON-shaped legacy YAML",
+			input: `{"global":{"User":"alice"}}`,
+			want:  "Host *\n    User alice\n",
+		},
+		{
+			name:  "flow v3",
+			input: `{schemaVersion: 3, documents: [{nodes: [{type: directive, directive: {keyword: Host, arguments: [example]}}]}]}`,
+			want:  "Host example\n",
+		},
+		{
+			name: "quoted v3 keys",
+			input: `"schemaVersion": 3
+"documents":
+  - nodes:
+      - type: directive
+        directive:
+          keyword: Host
+          arguments: [example]
+`,
+			want: "Host example\n",
+		},
+		{
+			name: "quoted legacy key",
+			input: `"global":
+  User: alice
+`,
+			want: "Host *\n    User alice\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Parser.ProcessLossless("YAML", test.input, Cmd.Args{ToSSH: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != test.want {
+				t.Fatalf("output = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- classify v3 and legacy YAML from the parsed root mapping instead of scanning arbitrary line prefixes
- preserve valid OpenSSH files whose `IgnoreUnknown` directive permits names such as `schemaVersion:`
- accept flow-style YAML, quoted root keys, and JSON-shaped legacy YAML

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- combined validation with the other v3 release fixes

This closes a v3 release blocker where valid SSH could be rejected and valid structured input could be passed through unchanged.