### PR TITLE
fix: preserve unsafe directives as raw-only nodes

### DIFF
--- a/pkg/sshconfig/schema.go
+++ b/pkg/sshconfig/schema.go
@@ -78,7 +78,12 @@ func (d *Document) ToSchema(path string) (SchemaDocument, error) {
 			if directive.Comment != nil {
 				view.Comment = string(clean.source[directive.Comment.Span.Start:directive.Comment.Span.End])
 			}
-			schemaNode.Directive = view
+			// Parsed source may contain bytes that are safe to preserve but not
+			// safe to expose as an editable directive. Keep those nodes raw-only
+			// instead of making the entire lossless export fail validation.
+			if ValidateDirectiveInput(view.Keyword, view.Arguments, view.Comment) == nil {
+				schemaNode.Directive = view
+			}
 		}
 		result.Nodes = append(result.Nodes, schemaNode)
 	}

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -116,6 +116,59 @@ func TestSchemaPreservesInvalidNodesAsRawBytes(t *testing.T) {
 	assertSchemaDocumentBytes(t, fromYAML, "config", input)
 }
 
+func TestSchemaPreservesUnsafeDirectiveViewsAsRawOnly(t *testing.T) {
+	t.Parallel()
+	tests := map[string][]byte{
+		"hash in keyword":              []byte("Foo#Bar baz\n"),
+		"vertical tab in keyword":      []byte("Foo\vBar baz\n"),
+		"NUL in keyword":               []byte("Host\x00 example\n"),
+		"NUL in unquoted argument":     []byte("Host example\x00hidden\n"),
+		"NUL in trailing comment text": []byte("Host example # note\x00hidden\n"),
+	}
+
+	for name, input := range tests {
+		name, input := name, input
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			document, err := Parse(input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			schemaDocument, err := document.ToSchema("config")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(schemaDocument.Nodes) != 1 || schemaDocument.Nodes[0].Type != "directive" || schemaDocument.Nodes[0].Directive != nil {
+				t.Fatalf("schema node = %#v, want raw-only directive", schemaDocument.Nodes)
+			}
+			schema := NewSchema(schemaDocument)
+			if err := schema.Validate(); err != nil {
+				t.Fatalf("raw-only schema does not validate: %v", err)
+			}
+
+			jsonData, err := MarshalSchemaJSON(schema)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fromJSON, err := UnmarshalSchemaJSON(jsonData)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertSchemaDocumentBytes(t, fromJSON, "config", input)
+
+			yamlData, err := MarshalSchemaYAML(schema)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fromYAML, err := UnmarshalSchemaYAML(yamlData)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertSchemaDocumentBytes(t, fromYAML, "config", input)
+		})
+	}
+}
+
 func TestSchemaEditPreservesMissingFinalNewline(t *testing.T) {
 	t.Parallel()
 	input := []byte("Host example\n  User old")


### PR DESCRIPTION
## Summary

- validate parsed directive views before exposing them as editable schema fields
- keep the authoritative `rawBase64` node when a keyword, argument, or comment cannot be rendered safely
- preserve NUL and control-bearing source bytes across JSON and YAML round trips

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- byte-for-byte JSON/YAML round-trip regression tests

This aligns export behavior with the v3 lossless contract instead of rejecting the entire document.