### PR TITLE
ci: verify bind-mount container output ownership

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,4 +122,20 @@ jobs:
 
       - name: Smoke-test published container
         if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        run: docker run --rm "ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_REF_NAME}" -version
+        shell: bash
+        run: |
+          image="ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_REF_NAME}"
+          docker run --rm "${image}" -version
+
+          smoke_dir="$(mktemp -d)"
+          printf 'Host smoke\n    User audit\n' > "${smoke_dir}/config"
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            --volume "${smoke_dir}:/ssh" \
+            "${image}" \
+            -to-yaml -src /ssh/config -dest /ssh/config.yaml
+          test -r "${smoke_dir}/config.yaml"
+          test "$(stat -c '%u:%g' "${smoke_dir}/config.yaml")" = "$(id -u):$(id -g)"
+          grep -q '^schemaVersion: 3$' "${smoke_dir}/config.yaml"
+
+          docker run --rm "soulteary/ssh-config:${GITHUB_REF_NAME}" -version

--- a/README.md
+++ b/README.md
@@ -68,19 +68,23 @@ docker pull ghcr.io/soulteary/ssh-config:latest
 Convert file (test.yaml) in the current directory to YAML (abc.yaml):
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
+docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd):/ssh" soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
 ```
+
+Passing the host UID and GID keeps files written to the bind mount owned by
+the current user. It is not required when the result is written only to
+standard output.
 
 Just want to see the conversion results:
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml
+docker run --rm -it -v "$(pwd):/ssh" soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml
 ```
 
 If you want to use Linux pipelines, you can first enter the Docker interactive command line:
 
 ```bash
-docker run --rm -it --entrypoint bash -v `pwd`:/ssh soulteary/ssh-config:latest
+docker run --rm -it --entrypoint bash -v "$(pwd):/ssh" soulteary/ssh-config:latest
 cat /ssh/test.yaml | ssh-config -lossless -to-yaml
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -73,19 +73,22 @@ docker pull ghcr.io/soulteary/ssh-config:latest
 将当前目录的配置文件转换并保存为新的文件：
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
+docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd):/ssh" soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
 ```
+
+写入挂载目录时传入宿主机当前用户的 UID 和 GID，可以避免生成
+`root:root` 且仅 root 可读的文件。只向标准输出打印结果时无需设置。
 
 如果你只想看看转换结果：
 
 ```bash
-docker run --rm -it -v `pwd`:/ssh soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml
+docker run --rm -it -v "$(pwd):/ssh" soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml
 ```
 
 如果你想使用 Linux 管道来操作文件，可以先进入 Docker 交互式命令行：
 
 ```bash
-docker run --rm -it --entrypoint bash -v `pwd`:/ssh soulteary/ssh-config:latest
+docker run --rm -it --entrypoint bash -v "$(pwd):/ssh" soulteary/ssh-config:latest
 cat /ssh/test.yaml | ssh-config -lossless -to-yaml
 ```
 


### PR DESCRIPTION
## Summary

- document `--user "$(id -u):$(id -g)"` for container writes to host bind mounts
- update both English and Chinese examples
- verify that a released container creates a readable v3 file owned by the host user
- smoke-test both the GHCR and Docker Hub images

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- workflow validation with actionlint (excluding its stale `queue: max` schema warning)
- Docker bind-mount behavior is exercised by the tag release job

This prevents the documented Linux workflow from leaving `root:root`, mode-0600 output on the host.