### PR TITLE
ci: harden v3 release verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
         run: |
           go mod tidy -diff
           test "$(go list -m -f '{{ .Path }}')" = "github.com/soulteary/ssh-config/v3"
+          command -v ssh
+          ssh -V
           go test -race ./...
           go vet ./...
           go build -trimpath -o "${RUNNER_TEMP}/ssh-config" .

--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -24,7 +24,8 @@ resolver, and atomic writer as the public Go API.
   lossless conversion becomes the default;
 - the Go module and import paths move from `/v2` to `/v3`.
 
-See [Migrating from v2 to v3](../migration-v3.md) for command and API examples.
+See [Migrating from v2 to v3](https://github.com/soulteary/ssh-config/blob/v3.0.0/docs/migration-v3.md)
+for command and API examples.
 
 ## Verification
 

--- a/pkg/sshconfig/openssh_integration_test.go
+++ b/pkg/sshconfig/openssh_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestOpenSSHRoundTripEffectiveConfiguration(t *testing.T) {
@@ -149,7 +150,7 @@ func FuzzEditMarshalReparse(f *testing.F) {
 	f.Add([]byte("Host example\n    User root\n"), "IdentityFile", "~/.ssh/work")
 	f.Add([]byte("# comment without newline"), "SetEnv", "FOO=bar")
 	f.Fuzz(func(t *testing.T, input []byte, keyword, value string) {
-		if keyword == "" || strings.ContainsAny(keyword, " \t\r\n=\"'") {
+		if !utf8.ValidString(keyword) || !utf8.ValidString(value) || ValidateDirectiveInput(keyword, []string{value}, "") != nil {
 			t.Skip()
 		}
 		doc, err := Parse(input)


### PR DESCRIPTION
## Summary

- require the OpenSSH client before running release tests so integration coverage cannot silently skip
- make the edit/marshal fuzz target skip values rejected by the public validation contract
- use a tag-stable absolute migration-guide link in the curated GitHub Release notes

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `govulncheck ./...`
- 10-second fuzz run (30,061 executions in combined validation)
- GoReleaser v2.18 configuration check and cross-platform snapshot

This makes the v3 tag workflow a reliable gate rather than allowing missing local prerequisites to reduce coverage.