### PR TITLE
fix: preserve legacy Host and directive argument semantics

### DIFF
--- a/pkg/sshconfig/migrate.go
+++ b/pkg/sshconfig/migrate.go
@@ -172,15 +172,28 @@ func writeLegacyHost(output *bytes.Buffer, name, notes string, config map[string
 	if err := ValidateDirectiveInput("Host", []string{name}, ""); err != nil {
 		return fmt.Errorf("sshconfig: invalid legacy host %q: %w", name, err)
 	}
+	hostArguments, err := parseLegacyArgumentText("Host", name)
+	if err != nil {
+		return fmt.Errorf("sshconfig: invalid legacy host %q: %w", name, err)
+	}
+	if len(hostArguments) == 0 {
+		return fmt.Errorf("sshconfig: invalid legacy host %q: Host requires at least one pattern", name)
+	}
 	for _, note := range strings.Split(notes, "\n") {
 		if err := ValidateDirectiveInput("Host", nil, note); err != nil {
 			return fmt.Errorf("sshconfig: invalid legacy note: %w", err)
 		}
 	}
+	argumentsByKey := make(map[string][]string, len(config))
 	for key, value := range config {
 		if err := ValidateDirectiveInput(key, []string{value}, ""); err != nil {
 			return fmt.Errorf("sshconfig: invalid legacy directive %q: %w", key, err)
 		}
+		arguments, err := parseLegacyArgumentText(key, value)
+		if err != nil {
+			return fmt.Errorf("sshconfig: invalid legacy directive %q: %w", key, err)
+		}
+		argumentsByKey[key] = arguments
 	}
 	for _, note := range strings.Split(notes, "\n") {
 		if note != "" {
@@ -190,16 +203,41 @@ func writeLegacyHost(output *bytes.Buffer, name, notes string, config map[string
 		}
 	}
 	output.WriteString("Host ")
-	output.WriteString(QuoteArgument(name))
+	writeArguments(output, hostArguments)
 	output.WriteByte('\n')
 	for _, key := range sortedMapKeys(config) {
 		output.WriteString("    ")
 		output.WriteString(key)
-		output.WriteByte(' ')
-		output.WriteString(QuoteArgument(config[key]))
+		if len(argumentsByKey[key]) > 0 {
+			output.WriteByte(' ')
+			writeArguments(output, argumentsByKey[key])
+		}
 		output.WriteByte('\n')
 	}
 	return nil
+}
+
+func parseLegacyArgumentText(keyword, value string) ([]string, error) {
+	line := keyword
+	if value != "" {
+		line += " " + value
+	}
+	document, err := Parse([]byte(line + "\n"))
+	if err != nil {
+		return nil, err
+	}
+	if diagnostics := document.Diagnostics(); len(diagnostics) > 0 {
+		return nil, fmt.Errorf("%s", diagnostics[0].Message)
+	}
+	nodes := document.Nodes()
+	if len(nodes) != 1 || nodes[0].Kind != NodeDirective || nodes[0].Directive == nil {
+		return nil, fmt.Errorf("cannot parse legacy argument text")
+	}
+	arguments := make([]string, 0, len(nodes[0].Directive.Arguments))
+	for _, argument := range nodes[0].Directive.Arguments {
+		arguments = append(arguments, argument.Value)
+	}
+	return arguments, nil
 }
 
 func sortedMapKeys[V any](values map[string]V) []string {

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -437,6 +437,51 @@ Group production:
 	}
 }
 
+func TestMigrateLegacyFormatsPreserveArgumentSemantics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input []byte
+		load  func([]byte, string) (Schema, error)
+	}{
+		{
+			name:  "JSON",
+			input: []byte(`[{"Name":"production staging","Data":{"SendEnv":"LANG LC_*"}}]`),
+			load:  MigrateLegacyJSON,
+		},
+		{
+			name:  "YAML",
+			input: []byte("Group production:\n  Hosts:\n    production staging:\n      config:\n        SendEnv: LANG LC_*\n"),
+			load:  MigrateLegacyYAML,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			schema, err := test.load(test.input, "config")
+			if err != nil {
+				t.Fatalf("migration error = %v", err)
+			}
+			document, err := schema.Document("config")
+			if err != nil {
+				t.Fatal(err)
+			}
+			output, err := document.MarshalPreserve()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(output), "Host production staging\n") {
+				t.Fatalf("multi-pattern Host was collapsed into one argument:\n%s", output)
+			}
+			if !strings.Contains(string(output), "SendEnv LANG LC_*\n") {
+				t.Fatalf("multi-argument directive was collapsed into one argument:\n%s", output)
+			}
+		})
+	}
+}
+
 func TestMigrateLegacyFormatsRejectCrossLineFields(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- parse legacy `Host` values with OpenSSH argument rules instead of quoting the complete value
- preserve multiple host patterns and multi-argument directives during JSON/YAML migration
- add regression coverage for both legacy formats

## Tests

- `go test ./...`