### PR TITLE
fix: reject missing names and preserve empty legacy hosts

### DIFF
--- a/pkg/sshconfig/migrate.go
+++ b/pkg/sshconfig/migrate.go
@@ -45,8 +45,10 @@ func MigrateLegacyYAML(data []byte, path string) (Schema, error) {
 		return Schema{}, fmt.Errorf("sshconfig: decode legacy YAML: %w", err)
 	}
 	var output bytes.Buffer
-	if err := writeLegacyHost(&output, "*", "", legacy.Global); err != nil {
-		return Schema{}, err
+	if len(legacy.Global) > 0 {
+		if err := writeLegacyHost(&output, "*", "", legacy.Global); err != nil {
+			return Schema{}, err
+		}
 	}
 	groupNames := orderedLegacyMapKeys(order.groups, legacy.Groups)
 	for _, groupName := range groupNames {
@@ -166,8 +168,8 @@ func schemaFromLegacyBytes(data []byte, path string) (Schema, error) {
 }
 
 func writeLegacyHost(output *bytes.Buffer, name, notes string, config map[string]string) error {
-	if name == "" || len(config) == 0 {
-		return nil
+	if name == "" {
+		return fmt.Errorf("sshconfig: legacy host name is empty")
 	}
 	if err := ValidateDirectiveInput("Host", []string{name}, ""); err != nil {
 		return fmt.Errorf("sshconfig: invalid legacy host %q: %w", name, err)

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -482,6 +482,81 @@ func TestMigrateLegacyFormatsPreserveArgumentSemantics(t *testing.T) {
 	}
 }
 
+func TestMigrateLegacyFormatsPreserveEmptyHosts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input []byte
+		load  func([]byte, string) (Schema, error)
+	}{
+		{
+			name:  "JSON",
+			input: []byte(`[{"Name":"empty","Notes":"keep this note"}]`),
+			load:  MigrateLegacyJSON,
+		},
+		{
+			name:  "YAML",
+			input: []byte("Group empty:\n  Hosts:\n    empty:\n      Notes: keep this note\n"),
+			load:  MigrateLegacyYAML,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			schema, err := test.load(test.input, "config")
+			if err != nil {
+				t.Fatalf("migration error = %v", err)
+			}
+			document, err := schema.Document("config")
+			if err != nil {
+				t.Fatal(err)
+			}
+			output, err := document.MarshalPreserve()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, expected := range []string{"# keep this note\n", "Host empty\n"} {
+				if !strings.Contains(string(output), expected) {
+					t.Fatalf("migrated empty host missing %q:\n%s", expected, output)
+				}
+			}
+		})
+	}
+}
+
+func TestMigrateLegacyFormatsRejectMissingHostName(t *testing.T) {
+	t.Parallel()
+
+	if _, err := MigrateLegacyJSON([]byte(`[{"Data":{"User":"deploy"}}]`), "config"); err == nil || !strings.Contains(err.Error(), "host name is empty") {
+		t.Fatalf("MigrateLegacyJSON() error = %v, want empty host name error", err)
+	}
+	if _, err := MigrateLegacyYAML([]byte("Group empty:\n  Hosts:\n    '':\n      config:\n        User: deploy\n"), "config"); err == nil || !strings.Contains(err.Error(), "host name is empty") {
+		t.Fatalf("MigrateLegacyYAML() error = %v, want empty host name error", err)
+	}
+}
+
+func TestMigrateLegacyYAMLDoesNotInventEmptyGlobalHost(t *testing.T) {
+	t.Parallel()
+
+	schema, err := MigrateLegacyYAML([]byte("Group empty:\n  Hosts:\n    empty: {}\n"), "config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, err := schema.Document("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := document.MarshalPreserve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(output), "Host *") {
+		t.Fatalf("migration invented an empty global Host block:\n%s", output)
+	}
+}
+
 func TestMigrateLegacyFormatsRejectCrossLineFields(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- keep empty legacy host records instead of silently dropping them
- reject legacy JSON records whose `Name` is missing or empty
- avoid inventing an empty global `Host *` block
- add JSON and YAML regression tests

## Dependency

This PR is stacked on #75 because both fixes touch the legacy migration path. Merge #75 first, then retarget this PR to `main` if GitHub does not do so automatically.

## Tests

- `go test ./...`