### PR TITLE
docs: remove deprecated -lossless from v3 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ ssh-config [options]
 Run without arguments to export `~/.ssh/config` as lossless v3 YAML on standard output:
 
 ```bash
-ssh-config -lossless
+ssh-config
 ```
 
 Or, use Linux pipes to manipulate files:
 
 ```bash
-cat input_file | ssh-config -lossless -to-yaml > output_file
+cat input_file | ssh-config -to-yaml > output_file
 ```
 
 ### Docker
@@ -68,7 +68,7 @@ docker pull ghcr.io/soulteary/ssh-config:latest
 Convert file (test.yaml) in the current directory to YAML (abc.yaml):
 
 ```bash
-docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd):/ssh" soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
+docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd):/ssh" soulteary/ssh-config:latest -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
 ```
 
 Passing the host UID and GID keeps files written to the bind mount owned by
@@ -78,14 +78,14 @@ standard output.
 Just want to see the conversion results:
 
 ```bash
-docker run --rm -it -v "$(pwd):/ssh" soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml
+docker run --rm -it -v "$(pwd):/ssh" soulteary/ssh-config:latest -to-yaml -src /ssh/test.yaml
 ```
 
 If you want to use Linux pipelines, you can first enter the Docker interactive command line:
 
 ```bash
 docker run --rm -it --entrypoint bash -v "$(pwd):/ssh" soulteary/ssh-config:latest
-cat /ssh/test.yaml | ssh-config -lossless -to-yaml
+cat /ssh/test.yaml | ssh-config -to-yaml
 ```
 
 ### Options
@@ -109,27 +109,27 @@ ssh-config
 2. Convert YAML format to SSH config format:
 
 ```bash
-ssh-config -lossless -to-ssh -src input.yaml -dest output.conf
+ssh-config -to-ssh -src input.yaml -dest output.conf
 ```
 
 3. Convert SSH config format to JSON format:
 
 ```bash
-ssh-config -lossless -to-json -src ~/.ssh/config -dest output.json
+ssh-config -to-json -src ~/.ssh/config -dest output.json
 ```
 
 4. Read from standard input, output to standard output, and save in YAML format:
 
 ```bash
-cat input.conf | ssh-config -lossless -to-yaml > output.yaml
+cat input.conf | ssh-config -to-yaml > output.yaml
 ```
 
 5. Losslessly edit a configuration through the v3 YAML representation:
 
 ```bash
-ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+ssh-config -to-yaml -src ~/.ssh/config -dest config.v3.yaml
 # Edit directive fields in config.v3.yaml. Unchanged lines retain their exact bytes.
-ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+ssh-config -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 ```
 
 The previous YAML/JSON formats remain readable and are migrated to schema v3 by default. Use `-legacy` only when an existing consumer still requires the old map/array output. Repeated values and directive ordering already absent from a legacy document cannot be reconstructed.

--- a/README_CN.md
+++ b/README_CN.md
@@ -45,19 +45,19 @@ ssh-config [options]
 不带参数运行时，程序读取 `~/.ssh/config`，并将无损 v3 YAML 输出到标准输出：
 
 ```bash
-ssh-config -lossless
+ssh-config
 ```
 
 需要指定输入和输出文件时，请使用 `-src` 和 `-dest`：
 
 ```bash
-ssh-config -lossless -to-yaml -src input_file -dest output_file
+ssh-config -to-yaml -src input_file -dest output_file
 ```
 
 或，使用 Linux 管道来操作文件：
 
 ```bash
-cat input_file | ssh-config -lossless -to-yaml > output_file
+cat input_file | ssh-config -to-yaml > output_file
 ```
 
 ### Docker
@@ -73,7 +73,7 @@ docker pull ghcr.io/soulteary/ssh-config:latest
 将当前目录的配置文件转换并保存为新的文件：
 
 ```bash
-docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd):/ssh" soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
+docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd):/ssh" soulteary/ssh-config:latest -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
 ```
 
 写入挂载目录时传入宿主机当前用户的 UID 和 GID，可以避免生成
@@ -82,14 +82,14 @@ docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd):/ssh" soulteary/ssh-co
 如果你只想看看转换结果：
 
 ```bash
-docker run --rm -it -v "$(pwd):/ssh" soulteary/ssh-config:latest -lossless -to-yaml -src /ssh/test.yaml
+docker run --rm -it -v "$(pwd):/ssh" soulteary/ssh-config:latest -to-yaml -src /ssh/test.yaml
 ```
 
 如果你想使用 Linux 管道来操作文件，可以先进入 Docker 交互式命令行：
 
 ```bash
 docker run --rm -it --entrypoint bash -v "$(pwd):/ssh" soulteary/ssh-config:latest
-cat /ssh/test.yaml | ssh-config -lossless -to-yaml
+cat /ssh/test.yaml | ssh-config -to-yaml
 ```
 
 ### 选项
@@ -107,27 +107,27 @@ cat /ssh/test.yaml | ssh-config -lossless -to-yaml
 1. 将 YAML 格式转换为 SSH 配置格式:
 
 ```bash
-ssh-config -lossless -to-ssh -src input.yaml -dest output.conf
+ssh-config -to-ssh -src input.yaml -dest output.conf
 ```
 
 2. 将 SSH 配置格式转换为 JSON 格式:
 
 ```bash
-ssh-config -lossless -to-json -src ~/.ssh/config -dest output.json
+ssh-config -to-json -src ~/.ssh/config -dest output.json
 ```
 
 3. 从标准输入读取，输出到标准输出，并以 YAML 格式保存:
 
 ```bash
-cat input.conf | ssh-config -lossless -to-yaml > output.yaml
+cat input.conf | ssh-config -to-yaml > output.yaml
 ```
 
 4. 通过 v3 YAML 格式无损编辑配置：
 
 ```bash
-ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+ssh-config -to-yaml -src ~/.ssh/config -dest config.v3.yaml
 # 修改 config.v3.yaml 中的 directive 字段；未修改的行会保留原始字节。
-ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+ssh-config -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 ```
 
 程序默认读取原有 YAML/JSON 格式并迁移为 v3 Schema。只有下游仍依赖旧 map/array 输出时才需要使用 `-legacy`；旧文档中已经丢失的重复值和指令顺序无法恢复。

--- a/docs/lossless-schema-v3.md
+++ b/docs/lossless-schema-v3.md
@@ -84,9 +84,9 @@ directive view.
 ## CLI workflow
 
 ```bash
-ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+ssh-config -to-yaml -src ~/.ssh/config -dest config.v3.yaml
 # Edit only directive.keyword, directive.arguments, or directive.comment.
-ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+ssh-config -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 ```
 
 Use `-to-json` instead of `-to-yaml` for a JSON envelope. Destination files are


### PR DESCRIPTION
## Summary

- update English and Chinese v3 usage examples to rely on lossless-by-default behavior
- update Docker, pipeline, and schema workflow examples
- keep the option reference and migration compatibility example so the deprecated alias remains discoverable

## Verification

- `git diff --check`
- confirmed `-lossless` remains only in compatibility documentation