### PR TITLE
docs: document remaining v3 breaking changes

### DIFF
--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -48,6 +48,16 @@ go mod tidy
 The schema's `schemaVersion: 3` is independent of the Go module and application
 version. The v3 application continues to read and write schema version 3.
 
+Version 3 requires Go 1.27 or newer. Applications and tools that build the
+module from source must upgrade their Go toolchain before moving from v2.
+
+## Release archives
+
+The Linux PowerPC archive changes from big-endian `ppc64` to little-endian
+`ppc64le`. Automated downloads should update the architecture name. Users who
+still require a big-endian `ppc64` binary must build v3 from source or remain on
+v2; v3 does not publish that prebuilt archive.
+
 ## Information that cannot be recovered
 
 Migrating an existing legacy document cannot recreate repeated directives,

--- a/docs/releases/v3.0.0.md
+++ b/docs/releases/v3.0.0.md
@@ -22,7 +22,10 @@ resolver, and atomic writer as the public Go API.
 - directory scanning requires `-legacy`;
 - `-lossless` remains as a deprecated no-op compatibility alias while
   lossless conversion becomes the default;
-- the Go module and import paths move from `/v2` to `/v3`.
+- the Go module and import paths move from `/v2` to `/v3`;
+- the minimum supported Go version increases to Go 1.27;
+- Linux PowerPC release archives move from big-endian `ppc64` to
+  little-endian `ppc64le`; v3 no longer publishes a `ppc64` archive.
 
 See [Migrating from v2 to v3](https://github.com/soulteary/ssh-config/blob/v3.0.0/docs/migration-v3.md)
 for command and API examples.


### PR DESCRIPTION
## Summary

- document the Go 1.27 minimum for v3 consumers and source builds
- document the Linux PowerPC archive change from `ppc64` to `ppc64le`
- add both changes to the migration guide and v3.0.0 release notes

## Verification

- `git diff --check`