### PR TITLE
fix: allow inserted directives to be edited again

### DIFF
--- a/pkg/sshconfig/edit.go
+++ b/pkg/sshconfig/edit.go
@@ -22,12 +22,30 @@ func (d *Document) ReplaceDirective(id NodeID, keyword string, arguments ...stri
 	}
 	node := &d.nodes[index]
 	if node.original == nil {
-		return fmt.Errorf("sshconfig: node %d is not a source directive", id)
+		raw, ok := d.replacement[id]
+		if !ok || node.Kind != NodeDirective || node.Directive == nil {
+			return fmt.Errorf("sshconfig: node %d is not a directive", id)
+		}
+		prefix := syntheticDirectivePrefix(raw)
+		d.replacement[id] = append(prefix, d.renderNewDirective(keyword, arguments)...)
+		node.Directive = syntheticDirective(keyword, arguments)
+		d.removed[id] = false
+		return nil
 	}
 	d.replacement[id] = d.renderReplacement(*node, keyword, arguments)
 	node.Kind = NodeDirective
 	node.Directive = syntheticDirective(keyword, arguments)
 	d.removed[id] = false
+	return nil
+}
+
+func syntheticDirectivePrefix(raw []byte) []byte {
+	if bytes.HasPrefix(raw, []byte("\r\n")) {
+		return []byte("\r\n")
+	}
+	if len(raw) > 0 && (raw[0] == '\n' || raw[0] == '\r') {
+		return raw[:1]
+	}
 	return nil
 }
 

--- a/pkg/sshconfig/writer_test.go
+++ b/pkg/sshconfig/writer_test.go
@@ -63,6 +63,58 @@ func TestRemoveAndInsertDirective(t *testing.T) {
 	}
 }
 
+func TestReplaceInsertedDirectives(t *testing.T) {
+	t.Parallel()
+	doc, _ := Parse([]byte("Host example"))
+	id, err := doc.InsertDirectiveAfter(0, "User", "root")
+	if err != nil {
+		t.Fatalf("InsertDirectiveAfter() error = %v", err)
+	}
+	if err := doc.ReplaceDirective(id, "User", "deploy user"); err != nil {
+		t.Fatalf("ReplaceDirective(inserted) error = %v", err)
+	}
+	appended, err := doc.AppendDirective("Port", "22")
+	if err != nil {
+		t.Fatalf("AppendDirective() error = %v", err)
+	}
+	if err := doc.ReplaceDirective(appended, "Port", "2200"); err != nil {
+		t.Fatalf("ReplaceDirective(appended) error = %v", err)
+	}
+	if err := doc.ReplaceDirective(appended, "Port", "2200"); err != nil {
+		t.Fatalf("ReplaceDirective(appended again) error = %v", err)
+	}
+	got, err := doc.MarshalPreserve()
+	if err != nil {
+		t.Fatalf("MarshalPreserve() error = %v", err)
+	}
+	want := "Host example\nUser \"deploy user\"\nPort 2200\n"
+	if string(got) != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestReplaceRemovedInsertedDirectiveRestoresIt(t *testing.T) {
+	t.Parallel()
+	doc, _ := Parse(nil)
+	id, err := doc.AppendDirective("User", "root")
+	if err != nil {
+		t.Fatalf("AppendDirective() error = %v", err)
+	}
+	if err := doc.RemoveNode(id); err != nil {
+		t.Fatalf("RemoveNode() error = %v", err)
+	}
+	if err := doc.ReplaceDirective(id, "User", "bob"); err != nil {
+		t.Fatalf("ReplaceDirective() error = %v", err)
+	}
+	got, err := doc.MarshalPreserve()
+	if err != nil {
+		t.Fatalf("MarshalPreserve() error = %v", err)
+	}
+	if want := "User bob\n"; string(got) != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
 func TestEditErrors(t *testing.T) {
 	t.Parallel()
 	doc, _ := Parse([]byte("# comment\n"))


### PR DESCRIPTION
## Summary

- allow `ReplaceDirective` to update nodes created by `InsertDirectiveAfter` and `AppendDirective`
- preserve the separator newline added after an unterminated source line
- restore a removed synthetic directive when it is replaced
- cover repeated edits and remove/replace behavior

## Tests

- `go test ./...`