### PR TITLE
ci: remove Codecov coverage upload

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -82,14 +82,6 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Upload coverage to Codecov
-        continue-on-error: true
-        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.out
-          fail_ci_if_error: false
-
       - name: Vet
         run: go vet ./...
 


### PR DESCRIPTION
## Summary

- remove the Codecov upload step from the main quality workflow
- remove the `CODECOV_TOKEN` dependency and the action that emits the Node.js 20 compatibility warning
- retain the existing local coverage artifact in this focused PR

A follow-up PR replaces the coverage and external report services with repository-local report actions.

## Verification

- `git diff --check`