### PR TITLE
ci: preserve Go 1.27 for vulnerability scanning

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -53,13 +53,13 @@ jobs:
       - name: Test and generate coverage report
         uses: soulteary/go-test-report-action@a5e77d563843af6c7a0cc3c573640fc2cd94934a # v1.1.0
         with:
-          version: v1.1.0
+          version: source
           commit: "false"
 
       - name: Generate Go quality report
         uses: soulteary/goreportcard-action@9480215498804c431e4561b4d3e50d925e16b9bd # v1.1.0
         with:
-          version: v1.1.0
+          version: source
           report: "false"
           commit: "false"
 
@@ -89,7 +89,7 @@ jobs:
       - name: Test with race detector and update coverage report
         uses: soulteary/go-test-report-action@a5e77d563843af6c7a0cc3c573640fc2cd94934a # v1.1.0
         with:
-          version: v1.1.0
+          version: source
           race: "true"
           commit: "true"
 
@@ -101,15 +101,15 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Update Go quality report
-        uses: soulteary/goreportcard-action@9480215498804c431e4561b4d3e50d925e16b9bd # v1.1.0
-        with:
-          version: v1.1.0
-          report: "false"
-          commit: "true"
-
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
 
       - name: Scan dependencies
         run: govulncheck ./...
+
+      - name: Update Go quality report
+        uses: soulteary/goreportcard-action@9480215498804c431e4561b4d3e50d925e16b9bd # v1.1.0
+        with:
+          version: source
+          report: "false"
+          commit: "true"


### PR DESCRIPTION
## Summary

- run `govulncheck` before `goreportcard-action`, whose internal toolchain setup otherwise leaves Go 1.26.6 on PATH
- build both report CLIs from their commit-pinned Action source instead of requesting missing v1.1.0 release assets and falling back after 404 warnings
- keep the report Actions pinned to the same reviewed commit SHAs introduced by #83

## Root cause

The post-merge Quality run for #83 completed race tests, coverage generation, artifact upload, and both report Actions successfully. It failed only at `govulncheck ./...` because the preceding Go Report Card Action selected Go 1.26.6 while this module requires Go 1.27.0.

## Verification

- `actionlint .github/workflows/quality.yml`
- `git diff --check`

Follow-up to #83.