### PR TITLE
test: improve v3 release readiness coverage

### DIFF
--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -10,8 +10,8 @@ The default command reads one physical SSH configuration file and writes v3
 YAML:
 
 ```bash
-ssh-config -lossless -to-yaml -src ~/.ssh/config -dest config.v3.yaml
-ssh-config -lossless -to-ssh -src config.v3.yaml -dest ~/.ssh/config
+ssh-config -to-yaml -src ~/.ssh/config -dest config.v3.yaml
+ssh-config -to-ssh -src config.v3.yaml -dest ~/.ssh/config
 ```
 
 Without `-src`, the default converter reads `~/.ssh/config`. It does not scan a

--- a/internal/parser/lossless_test.go
+++ b/internal/parser/lossless_test.go
@@ -114,6 +114,34 @@ func TestProcessLosslessRejectsInvalidStructuredInput(t *testing.T) {
 	}
 }
 
+func TestProcessLosslessClassifiesMalformedStructuredPrefixes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "schema version", input: "schemaVersion: [\n", want: "decode v3 YAML"},
+		{name: "documents", input: "documents: [\n", want: "decode v3 YAML"},
+		{name: "quoted documents", input: "\"documents\": [\n", want: "decode v3 YAML"},
+		{name: "global", input: "global: [\n", want: "decode legacy YAML"},
+		{name: "default", input: "default: [\n", want: "decode legacy YAML"},
+		{name: "group", input: "Group work: [\n", want: "decode legacy YAML"},
+		{name: "flow mapping", input: "{broken\n", want: "neither v3 nor legacy YAML"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Parser.ProcessLossless("YAML", test.input, Cmd.Args{ToSSH: true})
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ProcessLossless() error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestProcessLosslessSelectsSchemaDocumentByPath(t *testing.T) {
 	t.Parallel()
 	input := `schemaVersion: 3

--- a/pkg/sshconfig/parser_test.go
+++ b/pkg/sshconfig/parser_test.go
@@ -132,6 +132,43 @@ func TestMalformedQuoteIsRetainedAndDiagnosed(t *testing.T) {
 	}
 }
 
+func TestDocumentAccessorsReturnIndependentData(t *testing.T) {
+	t.Parallel()
+
+	var nilDocument *Document
+	if nilDocument.Bytes() != nil || nilDocument.Nodes() != nil || nilDocument.Diagnostics() != nil || nilDocument.Raw(Span{}) != nil {
+		t.Fatal("nil document accessors should return nil")
+	}
+	if got := nilDocument.Newline(); got != "\n" {
+		t.Fatalf("nil document newline = %q, want LF", got)
+	}
+
+	document, err := Parse([]byte("Host \"unfinished\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bytesCopy := document.Bytes()
+	bytesCopy[0] = 'X'
+	if got := string(document.Bytes()); got != "Host \"unfinished\n" {
+		t.Fatalf("Bytes() exposed document storage: %q", got)
+	}
+
+	diagnostics := document.Diagnostics()
+	if len(diagnostics) != 1 {
+		t.Fatalf("diagnostics = %#v, want one entry", diagnostics)
+	}
+	diagnostics[0].Message = "changed"
+	if document.Diagnostics()[0].Message == "changed" {
+		t.Fatal("Diagnostics() exposed document storage")
+	}
+
+	for _, span := range []Span{{Start: -1}, {Start: 2, End: 1}, {End: len(document.Bytes()) + 1}} {
+		if raw := document.Raw(span); raw != nil {
+			t.Fatalf("Raw(%+v) = %q, want nil", span, raw)
+		}
+	}
+}
+
 func TestParseArgumentsMatchesOpenSSHArgvSplit(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/pkg/sshconfig/schema_test.go
+++ b/pkg/sshconfig/schema_test.go
@@ -313,6 +313,175 @@ func TestSchemaStrictValidation(t *testing.T) {
 	}
 }
 
+func TestSchemaRejectsInvalidEnvelopeAndMarshalInput(t *testing.T) {
+	t.Parallel()
+	encode := func(raw string) string {
+		return base64.StdEncoding.EncodeToString([]byte(raw))
+	}
+	tests := []struct {
+		name   string
+		schema Schema
+		want   string
+	}{
+		{name: "no documents", schema: Schema{SchemaVersion: SchemaVersion}, want: "no documents"},
+		{
+			name: "duplicate path",
+			schema: NewSchema(
+				SchemaDocument{Path: "config"},
+				SchemaDocument{Path: "config"},
+			),
+			want: "duplicate schema document path",
+		},
+		{
+			name:   "unknown node type",
+			schema: NewSchema(SchemaDocument{Nodes: []SchemaNode{{Type: "future", RawBase64: encode("data\n")}}}),
+			want:   "unknown type",
+		},
+		{
+			name:   "empty keyword",
+			schema: NewSchema(SchemaDocument{Nodes: []SchemaNode{{Type: "directive", Directive: &SchemaDirective{}}}}),
+			want:   "empty keyword",
+		},
+		{
+			name:   "empty directive node",
+			schema: NewSchema(SchemaDocument{Nodes: []SchemaNode{{Type: "directive"}}}),
+			want:   "no directive or raw bytes",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if err := test.schema.Validate(); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Validate() error = %v, want substring %q", err, test.want)
+			}
+			if _, err := MarshalSchemaJSON(test.schema); err == nil {
+				t.Fatal("MarshalSchemaJSON() accepted an invalid schema")
+			}
+			if _, err := MarshalSchemaYAML(test.schema); err == nil {
+				t.Fatal("MarshalSchemaYAML() accepted an invalid schema")
+			}
+		})
+	}
+}
+
+func TestSchemaDocumentReportsUnknownPath(t *testing.T) {
+	t.Parallel()
+	schema := NewSchema(SchemaDocument{Path: "config"})
+	if _, err := schema.Document("missing"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("Document() error = %v, want missing path error", err)
+	}
+}
+
+func TestSchemaEditedDirectivePreservesLineEndingsAndNormalizesComments(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "LF", input: "Host old\n", want: "Host new # migrated\n"},
+		{name: "CRLF", input: "Host old\r\n", want: "Host new # migrated\r\n"},
+		{name: "CR", input: "Host old\r", want: "Host new # migrated\r"},
+		{name: "no final newline", input: "Host old", want: "Host new # migrated"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			document, err := Parse([]byte(test.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			schemaDocument, err := document.ToSchema("")
+			if err != nil {
+				t.Fatal(err)
+			}
+			schemaDocument.Nodes[0].Directive.Arguments = []string{"new"}
+			schemaDocument.Nodes[0].Directive.Comment = "migrated"
+			reconstructed, err := schemaDocument.Document()
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := reconstructed.MarshalPreserve()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != test.want {
+				t.Fatalf("edited directive = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateLegacyYAMLRejectsUnknownAndNonStringFields(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "unknown group field", input: "Group work:\n  Unknown: true\n", want: "unknown YAML field"},
+		{name: "unknown host field", input: "Group work:\n  Hosts:\n    example:\n      Unknown: true\n", want: "unknown YAML field"},
+		{name: "unknown extra field", input: "Group work:\n  Hosts:\n    example:\n      Extra:\n        suffix: invalid\n", want: "unknown YAML field"},
+		{name: "non-string root key", input: "1: {}\n", want: "non-string YAML field in document"},
+		{name: "non-string group key", input: "Group work:\n  1: value\n", want: "non-string YAML field in Group work"},
+		{name: "non-string host key", input: "Group work:\n  Hosts:\n    1: {}\n", want: "non-string YAML field in Group work.Hosts"},
+		{name: "non-string config key", input: "Group work:\n  Hosts:\n    example:\n      config:\n        1: value\n", want: "non-string YAML field in Group work.Hosts.example.config"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateLegacyYAML([]byte(test.input))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ValidateLegacyYAML() error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestMigrateLegacyYAMLResolvesMergeSequence(t *testing.T) {
+	t.Parallel()
+	input := []byte(`Group first: &first
+  Prefix: first-
+  Common:
+    User: alice
+Group second: &second
+  Prefix: second-
+  Common:
+    Port: "22"
+Group merged:
+  <<: [*first, *second]
+  Hosts:
+    example: {}
+`)
+
+	schema, err := MigrateLegacyYAML(input, "config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, err := schema.Document("config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	output, err := document.MarshalPreserve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Host first-example", "User alice"} {
+		if !strings.Contains(string(output), want) {
+			t.Fatalf("merged migration missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(string(output), "second-example") || strings.Contains(string(output), "Port 22") {
+		t.Fatalf("later merge operands overrode the first mapping:\n%s", output)
+	}
+}
+
 func TestSchemaDocumentPathSelection(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- remove the deprecated `-lossless` flag from the recommended v3 migration commands;
- cover malformed structured-input classification and strict v3 schema validation failures;
- verify `Document` accessors return independent data;
- cover edited directive comments and LF, CRLF, CR, and missing-final-newline behavior;
- cover legacy YAML unknown/non-string fields and merge-sequence precedence.

## Coverage

- tests: **198 → 205**
- total coverage: **89.51% → 92.15%**
- `internal/parser`: **89.01% → 91.45%**
- `pkg/sshconfig`: **86.87% → 91.11%**

## Verification

- `go mod tidy -diff`
- `go test ./... -covermode=atomic`
- `go test -race ./...`
- `go vet ./...`
- `govulncheck ./...`
- `go build -trimpath .`
- release snapshot workflow: https://github.com/soulteary/ssh-config/actions/runs/33045779873