### PR TITLE
fix: refresh validation diagnostics after edits

### DIFF
--- a/pkg/sshconfig/edit.go
+++ b/pkg/sshconfig/edit.go
@@ -34,7 +34,7 @@ func (d *Document) ReplaceDirective(id NodeID, keyword string, arguments ...stri
 	}
 	d.replacement[id] = d.renderReplacement(*node, keyword, arguments)
 	node.Kind = NodeDirective
-	node.Directive = syntheticDirective(keyword, arguments)
+	node.Directive = syntheticDirectiveAt(keyword, arguments, node.original.Keyword.Position)
 	d.removed[id] = false
 	return nil
 }
@@ -196,11 +196,16 @@ func QuoteArgument(argument string) string {
 }
 
 func syntheticDirective(keyword string, arguments []string) *Directive {
+	return syntheticDirectiveAt(keyword, arguments, Position{})
+}
+
+func syntheticDirectiveAt(keyword string, arguments []string, position Position) *Directive {
 	parsed := make([]Argument, 0, len(arguments))
 	for _, argument := range arguments {
 		parsed = append(parsed, Argument{Value: argument})
 	}
 	return &Directive{
+		Keyword:      Token{Position: position},
 		KeywordValue: strings.ToLower(keyword),
 		Arguments:    parsed,
 	}

--- a/pkg/sshconfig/validate.go
+++ b/pkg/sshconfig/validate.go
@@ -47,8 +47,15 @@ func (d *Document) Validate(options ValidateOptions) []ValidationIssue {
 	}
 	issues := make([]ValidationIssue, 0, len(d.diagnostics))
 	for _, diagnostic := range d.diagnostics {
+		nodeID := d.nodeIDAtOffset(diagnostic.Position.Offset)
+		if d.removed[nodeID] {
+			continue
+		}
+		if _, replaced := d.replacement[nodeID]; replaced {
+			continue
+		}
 		issues = append(issues, ValidationIssue{
-			NodeID:   d.nodeIDAtOffset(diagnostic.Position.Offset),
+			NodeID:   nodeID,
 			Position: diagnostic.Position,
 			Severity: SeverityError,
 			Code:     "invalid-syntax",

--- a/pkg/sshconfig/validate_test.go
+++ b/pkg/sshconfig/validate_test.go
@@ -85,3 +85,56 @@ func TestUnknownDirectivePolicies(t *testing.T) {
 		t.Fatalf("error issues = %#v", fail)
 	}
 }
+
+func TestValidateDropsDiagnosticsForRepairedOrRemovedNodes(t *testing.T) {
+	t.Parallel()
+
+	for _, action := range []string{"replace", "remove"} {
+		action := action
+		t.Run(action, func(t *testing.T) {
+			doc, err := Parse([]byte("Host example\nUser \"unfinished\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := doc.Validate(ValidateOptions{}); len(got) == 0 {
+				t.Fatal("invalid source did not produce a diagnostic")
+			}
+
+			switch action {
+			case "replace":
+				if err := doc.ReplaceDirective(1, "User", "deploy"); err != nil {
+					t.Fatal(err)
+				}
+			case "remove":
+				if err := doc.RemoveNode(1); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			for _, issue := range doc.Validate(ValidateOptions{}) {
+				if issue.Code == "invalid-syntax" {
+					t.Fatalf("stale syntax issue after %s: %#v", action, issue)
+				}
+			}
+		})
+	}
+}
+
+func TestValidatePreservesPositionAfterDirectiveReplacement(t *testing.T) {
+	t.Parallel()
+
+	doc, err := Parse([]byte("Host example\nUser deploy\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := doc.ReplaceDirective(1, "FutureOption", "value"); err != nil {
+		t.Fatal(err)
+	}
+	issues := doc.Validate(ValidateOptions{UnknownDirective: UnknownDirectiveError})
+	if len(issues) != 1 || issues[0].Code != "unknown-directive" {
+		t.Fatalf("issues = %#v", issues)
+	}
+	if issues[0].Position.Line != 2 || issues[0].Position.Column != 1 {
+		t.Fatalf("position = %#v, want line 2 column 1", issues[0].Position)
+	}
+}


### PR DESCRIPTION
## Summary

- drop parse diagnostics for nodes that have been repaired or removed
- preserve the original source position when replacing a directive
- cover repair, removal, and post-edit validation positions

## Why

`Document.Validate` previously retained stale `invalid-syntax` issues after an invalid node was replaced or removed. Replaced directives also lost their original position and could report later validation issues at line 1.

## Verification

- `git diff --check`
- GitHub Actions will run the Go 1.27 test suite and quality gates