### PR TITLE
fix: reject special files during config scans

### DIFF
--- a/internal/fn/scanner.go
+++ b/internal/fn/scanner.go
@@ -62,11 +62,15 @@ func isLegacyDirectoryConfigFile(path string) bool {
 }
 
 func hasConfigDirective(path string, accept func(string) bool) bool {
-	file, err := os.Open(path)
+	file, err := openConfigFile(path)
 	if err != nil {
 		return false
 	}
 	defer file.Close()
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
 
 	scanner := bufio.NewScanner(file)
 	scanner.Buffer(make([]byte, 64*1024), maxScannedConfigLine)
@@ -101,6 +105,9 @@ func ReadSSHConfigs(sshPath string) (*SSHConfig, error) {
 	}
 
 	if !info.IsDir() {
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("source path %s is not a regular file", sshPath)
+		}
 		if !isFileReadable(info) {
 			return config, nil
 		}
@@ -128,6 +135,9 @@ func ReadSSHConfigs(sshPath string) (*SSHConfig, error) {
 			return nil
 		}
 		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		if !info.Mode().IsRegular() {
 			return nil
 		}
 
@@ -158,11 +168,15 @@ func ReadSSHConfigs(sshPath string) (*SSHConfig, error) {
 }
 
 func ReadSingleConfig(path string) *ConfigFile {
-	file, err := os.Open(path)
+	file, err := openConfigFile(path)
 	if err != nil {
 		return nil
 	}
 	defer file.Close()
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return nil
+	}
 
 	config := &ConfigFile{
 		Path:  path,

--- a/internal/fn/scanner_open_other.go
+++ b/internal/fn/scanner_open_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package fn
+
+import "os"
+
+func openConfigFile(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/internal/fn/scanner_open_unix.go
+++ b/internal/fn/scanner_open_unix.go
@@ -1,0 +1,12 @@
+//go:build unix
+
+package fn
+
+import (
+	"os"
+	"syscall"
+)
+
+func openConfigFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+}

--- a/internal/fn/scanner_unix_test.go
+++ b/internal/fn/scanner_unix_test.go
@@ -1,0 +1,77 @@
+//go:build unix
+
+package fn
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestScannerRejectsFIFOWithoutBlocking(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	fifo := filepath.Join(directory, "config.fifo")
+	if err := syscall.Mkfifo(fifo, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{}, 1)
+	go func() {
+		if IsConfigFile(fifo) {
+			t.Error("FIFO was identified as an SSH config file")
+		}
+		if config := ReadSingleConfig(fifo); config != nil {
+			t.Errorf("ReadSingleConfig(FIFO) = %#v, want nil", config)
+		}
+		if _, err := ReadSSHConfigs(fifo); err == nil {
+			t.Error("ReadSSHConfigs(FIFO) succeeded")
+		}
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scanner blocked while opening a FIFO")
+	}
+}
+
+func TestDirectoryScanSkipsFIFO(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	fifo := filepath.Join(directory, "blocked")
+	if err := syscall.Mkfifo(fifo, 0600); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(directory, "config")
+	if err := os.WriteFile(configPath, []byte("Host example\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan *SSHConfig, 1)
+	errs := make(chan error, 1)
+	go func() {
+		config, err := ReadSSHConfigs(directory)
+		if err != nil {
+			errs <- err
+			return
+		}
+		done <- config
+	}()
+
+	select {
+	case err := <-errs:
+		t.Fatal(err)
+	case config := <-done:
+		if _, ok := config.Configs[configPath]; !ok {
+			t.Fatalf("regular config was not scanned: %#v", config.Configs)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("directory scan blocked on a FIFO")
+	}
+}


### PR DESCRIPTION
## Summary

- open Unix config candidates with `O_NONBLOCK`
- reject non-regular source paths before scanning or reading
- skip FIFOs and device files during legacy directory walks
- cover direct FIFO input and mixed directory scans without blocking

## Why

The legacy scanner opened candidate files before verifying their type. A FIFO or device file could therefore block `-legacy -src <directory>` indefinitely, and explicit special-file sources had the same problem.

## Verification

- `git diff --check`
- GitHub Actions will run the Go 1.27 test suite and race detector