### PR TITLE
fix: honor explicit CLI input and output paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ cat /ssh/test.yaml | ssh-config -to-yaml
 ### Options
 
 - `-to-yaml, -to-json, -to-ssh`: Specify output format (yaml/json/config), only one output format can be specified at a time.
-- `-src`: Specify the source file. When omitted, lossless mode reads `~/.ssh/config`; legacy mode scans `~/.ssh`.
-- `-dest`: Specify the path to save the configuration file. Its parent directory must already exist. When omitted, the converted result is written to standard output.
+- `-src`: Specify the source file. An explicit path takes precedence over piped standard input. When omitted, lossless mode reads `~/.ssh/config`; legacy mode scans `~/.ssh`.
+- `-dest`: Specify the path to save the configuration file, including when input comes from standard input. Its parent directory must already exist. When omitted, the converted result is written to standard output.
 - `-document-path`: Select a document by its `path` when `-to-ssh` reads a multi-document v3 schema.
 - `-legacy`: Use the previous lossy map/array formats. This mode also enables directory scanning.
 - `-lossless`: Deprecated compatibility alias; lossless conversion is already the default in v3.

--- a/README_CN.md
+++ b/README_CN.md
@@ -95,8 +95,8 @@ cat /ssh/test.yaml | ssh-config -to-yaml
 ### 选项
 
 - `-to-yaml, -to-json, -to-ssh`: 指定输出格式 (yaml/json/config)，同一时间，输出格式只能指定为一种。
-- `-src`: 指定输入文件；省略时无损模式读取 `~/.ssh/config`，旧模式扫描 `~/.ssh`
-- `-dest`: 指定要保存的配置文件路径；父目录必须已存在，省略时将转换结果写入标准输出
+- `-src`: 指定输入文件；显式路径优先于管道标准输入，省略时无损模式读取 `~/.ssh/config`，旧模式扫描 `~/.ssh`
+- `-dest`: 指定要保存的配置文件路径，包括输入来自标准输入时；父目录必须已存在，省略时将转换结果写入标准输出
 - `-document-path`: 当 `-to-ssh` 读取包含多个文档的 v3 Schema 时，按 `path` 选择要转换的文档
 - `-legacy`: 使用原有的有损 map/array 格式，并启用目录扫描。
 - `-lossless`: 已弃用的兼容参数；v3 已默认使用无损转换。

--- a/main.go
+++ b/main.go
@@ -58,7 +58,10 @@ func Run(args Cmd.Args, deps Dependencies) error {
 		return fmt.Errorf("%s", notValidReason)
 	}
 
-	pipeMode := deps.CheckUseStdin()
+	// An explicit source always wins over an inherited or redirected stdin.
+	// This keeps automation deterministic when a caller supplies -src while its
+	// parent process also connects a non-terminal stdin.
+	pipeMode := args.Src == "" && deps.CheckUseStdin()
 	if !pipeMode && args.Src == "" {
 		if deps.UserHomeDir == nil {
 			err := fmt.Errorf("user home directory lookup is unavailable")
@@ -114,7 +117,7 @@ func Run(args Cmd.Args, deps Dependencies) error {
 		return err
 	}
 
-	if pipeMode {
+	if args.Dest == "" {
 		if !args.Legacy && deps.WriteOutput != nil {
 			if err := deps.WriteOutput(result); err != nil {
 				deps.errorln("Error writing output:", err)
@@ -123,31 +126,20 @@ func Run(args Cmd.Args, deps Dependencies) error {
 		} else {
 			deps.Println(string(result))
 		}
-	} else {
-		if args.Dest == "" {
-			if !args.Legacy && deps.WriteOutput != nil {
-				if err := deps.WriteOutput(result); err != nil {
-					deps.errorln("Error writing output:", err)
-					return err
-				}
-			} else {
-				deps.Println(string(result))
-			}
-			return nil
-		}
-
-		save := deps.SaveFile
-		if !args.Legacy && deps.SaveLossless != nil {
-			save = deps.SaveLossless
-		}
-		err := save(args.Dest, result)
-		if err != nil {
-			deps.errorln("Error saving file:", err)
-			return err
-		}
-		deps.Println("File has been saved successfully")
-		deps.Println("File path:", args.Dest)
+		return nil
 	}
+
+	save := deps.SaveFile
+	if !args.Legacy && deps.SaveLossless != nil {
+		save = deps.SaveLossless
+	}
+	err = save(args.Dest, result)
+	if err != nil {
+		deps.errorln("Error saving file:", err)
+		return err
+	}
+	deps.Println("File has been saved successfully")
+	deps.Println("File path:", args.Dest)
 
 	return nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -260,6 +260,77 @@ func TestRunPipeDoesNotRequireHomeDirectory(t *testing.T) {
 	}
 }
 
+func TestRunExplicitSourceTakesPrecedenceOverStdin(t *testing.T) {
+	t.Parallel()
+
+	source := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(source, []byte("Host source\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var output []byte
+	err := Run(Cmd.Args{ToSSH: true, Src: source}, Dependencies{
+		Println:       func(...interface{}) (int, error) { return 0, nil },
+		CheckUseStdin: func() bool { return true },
+		ReadStdin: func() ([]byte, error) {
+			t.Fatal("stdin was read even though -src was explicit")
+			return nil, nil
+		},
+		GetContent: func(path string) ([]byte, error) {
+			if path != source {
+				t.Fatalf("source path = %q, want %q", path, source)
+			}
+			return []byte("Host source\n"), nil
+		},
+		Process: func(_ string, input string, _ Cmd.Args) ([]byte, error) {
+			return []byte(input), nil
+		},
+		WriteOutput: func(data []byte) error {
+			output = append([]byte(nil), data...)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(output) != "Host source\n" {
+		t.Fatalf("output = %q", output)
+	}
+}
+
+func TestRunPipeHonorsDestination(t *testing.T) {
+	t.Parallel()
+
+	var savedPath string
+	var savedData []byte
+	err := Run(Cmd.Args{ToYAML: true, Dest: "config.yaml"}, Dependencies{
+		Println:       func(...interface{}) (int, error) { return 0, nil },
+		CheckUseStdin: func() bool { return true },
+		ReadStdin:     func() ([]byte, error) { return []byte("Host input\n"), nil },
+		Process: func(_ string, input string, _ Cmd.Args) ([]byte, error) {
+			return []byte(input), nil
+		},
+		SaveFile: func(string, []byte) error {
+			t.Fatal("legacy saver called")
+			return nil
+		},
+		SaveLossless: func(path string, data []byte) error {
+			savedPath = path
+			savedData = append([]byte(nil), data...)
+			return nil
+		},
+		WriteOutput: func([]byte) error {
+			t.Fatal("stdout was used even though -dest was explicit")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if savedPath != "config.yaml" || string(savedData) != "Host input\n" {
+		t.Fatalf("saved path/data = %q, %q", savedPath, savedData)
+	}
+}
+
 func TestRunDefaultModeReadsItsStructuredOutput(t *testing.T) {
 	original := []byte("Host=example\r\nIdentityFile first\r\nIdentityFile second")
 	formats := []struct {


### PR DESCRIPTION
## Summary

- make an explicit `-src` take precedence over redirected stdin
- honor `-dest` when input comes from stdin
- document the precedence in both READMEs
- add regression tests for both combinations

## Why

The CLI previously ignored `-src` whenever stdin was non-terminal and silently ignored `-dest` in pipe mode. This made automation depend on inherited process IO rather than explicit arguments.

## Verification

- `git diff --check`
- GitHub Actions will run the Go 1.27 test suite