### PR TITLE
ci: add scheduled fuzz and platform tests

### DIFF
--- a/.github/workflows/extended-tests.yml
+++ b/.github/workflows/extended-tests.yml
@@ -1,0 +1,62 @@
+name: Extended tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 3 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: extended-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  platforms:
+    name: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Test
+        run: go test ./...
+
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - FuzzParsePreservesBytes
+          - FuzzEditMarshalReparse
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Fuzz ${{ matrix.target }}
+        shell: bash
+        env:
+          FUZZ_TARGET: ${{ matrix.target }}
+        run: go test ./pkg/sshconfig -run='^$' -fuzz="^${FUZZ_TARGET}$" -fuzztime=60s


### PR DESCRIPTION
## Summary

- run the full Go test suite weekly on native macOS and Windows runners
- exercise both existing fuzz targets for 60 seconds each on a weekly schedule
- support manual dispatch for on-demand platform and fuzz verification
- keep the expensive jobs off the regular pull-request path

## Validation

- `git diff --check`
- fuzz target names match the repository test functions
- action references reuse the repository's pinned checkout and setup-go SHAs