### PR TITLE
docs: add contribution and repository governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @soulteary

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report a reproducible defect in parsing, editing, conversion, or CLI behavior
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: Do not report vulnerabilities here. Use the private advisory link in SECURITY.md.
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      placeholder: v3.0.0 or a full commit SHA
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Command and minimal synthetic input
+      description: Remove keys, tokens, usernames, and real hostnames.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behavior
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/soulteary/ssh-config/security/advisories/new
+    about: Report suspected vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Propose a focused improvement to the library, schema, or CLI
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What limitation or workflow problem should be solved?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Include compatibility and lossless round-trip expectations where relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: checkboxes
+    id: compatibility
+    attributes:
+      label: Compatibility
+      options:
+        - label: I considered existing CLI users and schema v3 consumers.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What changed, and why? -->
+
+## Validation
+
+<!-- List the commands, workflows, and manual checks that were run. -->
+
+- [ ] I kept this pull request focused on one concern.
+- [ ] I added or updated regression tests when behavior changed.
+- [ ] I ran `go mod tidy -diff`, `go test ./...`, and `go vet ./...` when applicable.
+- [ ] I did not include credentials, private keys, or production hostnames.
+- [ ] I updated user-facing documentation when behavior or release procedures changed.

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,0 +1,27 @@
+name: Required
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: required-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  policy:
+    name: Repository policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Check patch whitespace
+        shell: bash
+        run: git diff --check "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thank you for helping improve `ssh-config`.
+
+## Before opening a change
+
+- Use an issue for behavior changes that need design discussion.
+- Use synthetic SSH configuration in reports and tests. Never commit keys,
+  tokens, production hostnames, or other credentials.
+- Keep pull requests focused on one concern and include regression tests for
+  bug fixes.
+
+## Development
+
+Install the Go version declared in `go.mod`, then run:
+
+```sh
+go mod tidy -diff
+go test ./...
+go vet ./...
+```
+
+Parser and editor changes must preserve unmodified bytes. Add a round-trip test
+when changing parsing, formatting, validation, or mutation behavior. File-system
+changes should cover symbolic links and non-regular files where applicable.
+
+Before requesting review, complete the pull request checklist and confirm that
+the relevant GitHub Actions checks pass.
+
+## Security reports
+
+Do not open a public issue for a suspected vulnerability. Follow
+[`SECURITY.md`](SECURITY.md) and use a private security advisory.

--- a/docs/repository-settings.md
+++ b/docs/repository-settings.md
@@ -1,0 +1,19 @@
+# Repository settings
+
+After the workflow in this change exists on the default branch, protect `main`
+with a branch ruleset. Repository settings are not versioned by a pull request,
+so an administrator must enable these controls in GitHub:
+
+- require pull requests before merging;
+- require at least one approval and dismiss stale approvals;
+- require a code-owner review;
+- require conversation resolution;
+- require the `Required / Repository policy` status check;
+- block force pushes and branch deletion;
+- do not allow bypass for repository administrators.
+
+The existing `Quality / PR tests and local reports` workflow is intentionally
+path-filtered and therefore should not be the only required check: documentation
+pull requests do not create that check. The always-running repository-policy
+job supplies a stable required-check context, while Quality continues to run
+tests and reports for source and workflow changes.


### PR DESCRIPTION
## Summary

- add a focused contribution guide and pull-request checklist
- add structured bug and feature issue forms, with private security-report routing
- add CODEOWNERS for repository-wide review ownership
- add an always-running, pinned `Required / Repository policy` check for stable branch-rule enforcement
- document the exact `main` ruleset settings an administrator must enable after merge

## Important

A pull request can version CODEOWNERS, workflows, and policy documentation, but GitHub branch protection itself is repository state. After this PR merges, an administrator still needs to enable the ruleset described in `docs/repository-settings.md`.

## Validation

- `git diff --check`
- all issue-form and workflow YAML files parse successfully