### PR TITLE
ci: make existing release recovery idempotent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,16 @@ jobs:
           printf 'publish=%s\n' "${publish}" >> "${GITHUB_OUTPUT}"
           printf 'tag=%s\n' "${tag}" >> "${GITHUB_OUTPUT}"
 
+      - name: Make existing-release recovery idempotent
+        if: github.event_name == 'workflow_dispatch' && steps.release.outputs.publish == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          config=".goreleaser.yaml"
+          test "$(grep -c '^release:$' "${config}")" = "1"
+          sed -i '/^release:$/a\  mode: replace\n  replace_existing_artifacts: true' "${config}"
+          grep -A2 '^release:$' "${config}"
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -16,4 +16,6 @@ the exact commit has passed the `Release candidate` workflow.
 
 For recovery when an immutable tag exists but its publishing run is missing,
 use the `publish` mode documented in the release notes. This recovery path
-checks out and verifies the existing tag; it never moves the tag.
+checks out and verifies the existing tag; it never moves the tag. Recovery
+replaces the existing release notes with the curated document and replaces any
+same-named assets, so a partially completed publication can be retried safely.


### PR DESCRIPTION
## Summary

- switch GoReleaser to `mode: replace` only during manual existing-tag recovery
- replace same-named assets during recovery so partial publication can be retried
- document the idempotent recovery behavior

## Why this is necessary

GoReleaser's default for an already existing release is `keep-existing`, which would preserve the current autogenerated v3.0.0 body even when `--release-notes` points at the curated document. The tagged `.goreleaser.yaml` cannot be changed without moving the immutable tag, so the workflow applies these two recovery-only settings to its checked-out workspace.

Normal tag-triggered releases are unchanged.

## Validation

- `git diff --check`
- workflow YAML parses successfully
- applied the exact GNU sed command to the tagged-style GoReleaser config and verified the resulting YAML parses with `mode: replace` and `replace_existing_artifacts: true`