### PR TITLE
ci: explain release candidate SHA mismatches

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       expected_commit:
-        description: Full commit SHA expected at the tip of main
+        description: Full SHA currently at the tip of main (not a release tag SHA)
         required: true
         type: string
 
@@ -36,8 +36,17 @@ jobs:
             echo "::error::expected_commit must be a full 40-character commit SHA"
             exit 1
           fi
-          test "$(git rev-parse HEAD)" = "${EXPECTED_COMMIT}"
-          test "$(git rev-parse origin/main)" = "${EXPECTED_COMMIT}"
+
+          head_commit="$(git rev-parse HEAD)"
+          main_commit="$(git rev-parse origin/main)"
+          if [[ "${head_commit}" != "${EXPECTED_COMMIT}" ]]; then
+            echo "::error::expected_commit ${EXPECTED_COMMIT} does not match checked-out main ${head_commit}"
+            exit 1
+          fi
+          if [[ "${main_commit}" != "${EXPECTED_COMMIT}" ]]; then
+            echo "::error::expected_commit ${EXPECTED_COMMIT} does not match origin/main ${main_commit}"
+            exit 1
+          fi
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0


### PR DESCRIPTION
## Summary

- clarify that `expected_commit` must be the current tip of `main`, not an existing release tag SHA
- replace silent `test` failures with actionable errors that show both expected and actual commits

## Why

A dispatch using the immutable `v3.0.0` tag commit (`4fdb4a6e...`) failed with only exit code 1 because current `main` is `4b9f4198...`. The release-candidate gate is intentionally limited to current `main`; this change preserves that safety property while making the misuse immediately diagnosable.

## Validation

- `git diff --check`
- verified the workflow shell logic against the current `main` and `v3.0.0` SHAs