### PR TITLE
fix: prevent silent legacy host loss

### DIFF
--- a/internal/parser/legacy_safety_test.go
+++ b/internal/parser/legacy_safety_test.go
@@ -54,6 +54,60 @@ Group work:
 	}
 }
 
+func TestGroupYAMLConfigPreservesHostWithoutConfig(t *testing.T) {
+	t.Parallel()
+
+	configs, err := Parser.GroupYAMLConfigStrict(`Group work:
+  Hosts:
+    example: {}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(configs) != 1 || configs[0].Name != "example" {
+		t.Fatalf("GroupYAMLConfigStrict() = %#v, want one empty example host", configs)
+	}
+
+	output := string(Parser.ConvertToSSH(configs))
+	if !strings.Contains(output, "Host example\n") {
+		t.Fatalf("ConvertToSSH() dropped empty host:\n%s", output)
+	}
+}
+
+func TestLegacyStructuredConfigRejectsMissingHostName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		parse func() error
+	}{
+		{
+			name: "JSON",
+			parse: func() error {
+				_, err := Parser.GroupJSONConfigStrict(`[{"Data":{"User":"deploy"}}]`)
+				return err
+			},
+		},
+		{
+			name: "YAML",
+			parse: func() error {
+				_, err := Parser.GroupYAMLConfigStrict("Group empty:\n  Hosts:\n    '':\n      config:\n        User: deploy\n")
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := test.parse()
+			if err == nil || !strings.Contains(err.Error(), "host name is empty") {
+				t.Fatalf("parse error = %v, want empty host name rejection", err)
+			}
+		})
+	}
+}
+
 func TestGroupSSHConfigRejectsLossyLegacyInputs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/parser/legacy_validate.go
+++ b/internal/parser/legacy_validate.go
@@ -11,6 +11,9 @@ import (
 func validateLegacyHostConfigs(configs []Define.HostConfig) error {
 	for index, host := range configs {
 		name := host.Extra.Prefix + host.Name
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("legacy host %d: host name is empty", index)
+		}
 		if err := sshconfig.ValidateDirectiveInput("Host", []string{name}, ""); err != nil {
 			return fmt.Errorf("legacy host %d: %w", index, err)
 		}

--- a/internal/parser/yaml.go
+++ b/internal/parser/yaml.go
@@ -183,8 +183,8 @@ func GroupYAMLConfigStrict(input string) ([]Define.HostConfig, error) {
 							}
 						}
 					}
-					hostConfigs = append(hostConfigs, hostConfig)
 				}
+				hostConfigs = append(hostConfigs, hostConfig)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- preserve legacy YAML hosts even when their config map is empty
- reject JSON/YAML legacy hosts whose effective `Host` name is empty
- add regression coverage for both the previously dropped empty host and missing names

This keeps `-legacy` explicitly lossy only where the schema cannot represent source details; it no longer silently removes an entire host entry.

## Validation

- `go test ./...`
- `git diff --check`