### PR TITLE
fix: make Include environment expansion match its API contract

### DIFF
--- a/pkg/sshconfig/include.go
+++ b/pkg/sshconfig/include.go
@@ -176,18 +176,50 @@ func expandIncludePattern(pattern string, options ResolveOptions) (string, error
 }
 
 func expandEnvironment(value string, environment map[string]string) (string, error) {
-	var missing string
-	expanded := os.Expand(value, func(name string) string {
-		result, ok := environment[name]
-		if !ok && missing == "" {
-			missing = name
+	var out strings.Builder
+	for index := 0; index < len(value); {
+		if value[index] != '$' || index+1 >= len(value) || value[index+1] != '{' {
+			out.WriteByte(value[index])
+			index++
+			continue
 		}
-		return result
-	})
-	if missing != "" {
-		return "", fmt.Errorf("environment variable %s is not set", missing)
+
+		endOffset := strings.IndexByte(value[index+2:], '}')
+		if endOffset < 0 {
+			return "", fmt.Errorf("unterminated environment variable expansion")
+		}
+		end := index + 2 + endOffset
+		name := value[index+2 : end]
+		if !validEnvironmentName(name) {
+			return "", fmt.Errorf("invalid environment variable name %q", name)
+		}
+		replacement, ok := environment[name]
+		if !ok {
+			return "", fmt.Errorf("environment variable %s is not set", name)
+		}
+		out.WriteString(replacement)
+		index = end + 1
 	}
-	return expanded, nil
+	return out.String(), nil
+}
+
+func validEnvironmentName(name string) bool {
+	if name == "" || !isEnvironmentNameStart(name[0]) {
+		return false
+	}
+	for index := 1; index < len(name); index++ {
+		character := name[index]
+		if !isEnvironmentNameStart(character) && (character < '0' || character > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func isEnvironmentNameStart(character byte) bool {
+	return character == '_' ||
+		(character >= 'a' && character <= 'z') ||
+		(character >= 'A' && character <= 'Z')
 }
 
 func expandPercentTokens(value string, tokens map[byte]string) (string, error) {

--- a/pkg/sshconfig/include_environment_test.go
+++ b/pkg/sshconfig/include_environment_test.go
@@ -1,0 +1,44 @@
+package sshconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExpandEnvironmentOnlyAcceptsBracedNames(t *testing.T) {
+	t.Parallel()
+	environment := map[string]string{"PROFILE": "work", "EMPTY": ""}
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr string
+	}{
+		{name: "braced name", input: "hosts/${PROFILE}/config", want: "hosts/work/config"},
+		{name: "unbraced dollar is literal", input: "hosts/$PROFILE/config", want: "hosts/$PROFILE/config"},
+		{name: "double dollar is literal", input: "hosts/$$/config", want: "hosts/$$/config"},
+		{name: "empty value", input: "hosts/${EMPTY}/config", want: "hosts//config"},
+		{name: "missing name", input: "${MISSING}", wantErr: "is not set"},
+		{name: "empty name", input: "${}", wantErr: "invalid environment variable name"},
+		{name: "invalid name", input: "${BAD-NAME}", wantErr: "invalid environment variable name"},
+		{name: "unterminated name", input: "${PROFILE", wantErr: "unterminated"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := expandEnvironment(test.input, environment)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("expandEnvironment() error = %v, want %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("expandEnvironment() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/sshconfig/include_test.go
+++ b/pkg/sshconfig/include_test.go
@@ -152,44 +152,6 @@ func TestResolveIncludesExpansionErrors(t *testing.T) {
 	}
 }
 
-func TestExpandEnvironmentOnlyAcceptsBracedNames(t *testing.T) {
-	t.Parallel()
-	environment := map[string]string{"PROFILE": "work", "EMPTY": ""}
-	tests := []struct {
-		name    string
-		input   string
-		want    string
-		wantErr string
-	}{
-		{name: "braced name", input: "hosts/${PROFILE}/config", want: "hosts/work/config"},
-		{name: "unbraced dollar is literal", input: "hosts/$PROFILE/config", want: "hosts/$PROFILE/config"},
-		{name: "double dollar is literal", input: "hosts/$$/config", want: "hosts/$$/config"},
-		{name: "empty value", input: "hosts/${EMPTY}/config", want: "hosts//config"},
-		{name: "missing name", input: "${MISSING}", wantErr: "is not set"},
-		{name: "empty name", input: "${}", wantErr: "invalid environment variable name"},
-		{name: "invalid name", input: "${BAD-NAME}", wantErr: "invalid environment variable name"},
-		{name: "unterminated name", input: "${PROFILE", wantErr: "unterminated"},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := expandEnvironment(test.input, environment)
-			if test.wantErr != "" {
-				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
-					t.Fatalf("expandEnvironment() error = %v, want %q", err, test.wantErr)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got != test.want {
-				t.Fatalf("expandEnvironment() = %q, want %q", got, test.want)
-			}
-		})
-	}
-}
-
 func writeTestConfig(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {

--- a/pkg/sshconfig/include_test.go
+++ b/pkg/sshconfig/include_test.go
@@ -152,6 +152,44 @@ func TestResolveIncludesExpansionErrors(t *testing.T) {
 	}
 }
 
+func TestExpandEnvironmentOnlyAcceptsBracedNames(t *testing.T) {
+	t.Parallel()
+	environment := map[string]string{"PROFILE": "work", "EMPTY": ""}
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr string
+	}{
+		{name: "braced name", input: "hosts/${PROFILE}/config", want: "hosts/work/config"},
+		{name: "unbraced dollar is literal", input: "hosts/$PROFILE/config", want: "hosts/$PROFILE/config"},
+		{name: "double dollar is literal", input: "hosts/$$/config", want: "hosts/$$/config"},
+		{name: "empty value", input: "hosts/${EMPTY}/config", want: "hosts//config"},
+		{name: "missing name", input: "${MISSING}", wantErr: "is not set"},
+		{name: "empty name", input: "${}", wantErr: "invalid environment variable name"},
+		{name: "invalid name", input: "${BAD-NAME}", wantErr: "invalid environment variable name"},
+		{name: "unterminated name", input: "${PROFILE", wantErr: "unterminated"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := expandEnvironment(test.input, environment)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("expandEnvironment() error = %v, want %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.want {
+				t.Fatalf("expandEnvironment() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func writeTestConfig(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {


### PR DESCRIPTION
## Summary

- expand only the documented `${NAME}` form
- leave `$NAME` and `$$` literal instead of inheriting `os.Expand` semantics
- validate portable environment variable names
- report missing, invalid, and unterminated expansions explicitly

The API documentation promises explicit-map `${NAME}` expansion; this change makes the implementation deterministic and prevents broader `$name` substitutions.

## Validation

- `go test ./...`
- `git diff --check`