### PR TITLE
refactor: read lossless source files directly

### DIFF
--- a/internal/fn/scanner.go
+++ b/internal/fn/scanner.go
@@ -19,6 +19,7 @@ package fn
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,6 +38,31 @@ type ConfigFile struct {
 
 type SSHConfig struct {
 	Configs map[string]*ConfigFile // key: 配置文件路径
+}
+
+// ReadConfigFile reads one physical config without passing it through the
+// legacy line scanner. This preserves long lines and every input byte for the
+// default lossless conversion path.
+func ReadConfigFile(path string) ([]byte, error) {
+	file, err := openConfigFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("open config file %s: %w", path, err)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("inspect config file %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("source path %s is not a regular file", path)
+	}
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("read config file %s: %w", path, err)
+	}
+	return content, nil
 }
 
 func IsExcluded(filename string) bool {

--- a/internal/fn/scanner_test.go
+++ b/internal/fn/scanner_test.go
@@ -116,6 +116,28 @@ Host example
 	}
 }
 
+func TestReadConfigFilePreservesLongLines(t *testing.T) {
+	content := []byte("Host example\n# " + strings.Repeat("x", 1024*1024+1) + "\n")
+	path := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(path, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fn.ReadConfigFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("ReadConfigFile() changed %d input bytes", len(content))
+	}
+}
+
+func TestReadConfigFileRejectsDirectories(t *testing.T) {
+	if _, err := fn.ReadConfigFile(t.TempDir()); err == nil {
+		t.Fatal("ReadConfigFile() accepted a directory")
+	}
+}
+
 func TestReadSSHConfigs(t *testing.T) {
 	// Create a temporary SSH directory with multiple config files
 	dir, err := os.MkdirTemp("", "ssh_test")

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ type Dependencies struct {
 	Println               func(...interface{}) (n int, err error)
 	PrintErr              func(...interface{}) (n int, err error)
 	GetContent            func(string) ([]byte, error)
+	GetLosslessContent    func(string) ([]byte, error)
 	SaveFile              func(string, []byte) error
 	SaveLossless          func(string, []byte) error
 	GetUserInputFromStdin func() string
@@ -94,7 +95,11 @@ func Run(args Cmd.Args, deps Dependencies) error {
 			return fmt.Errorf("%s", notValidReason)
 		}
 
-		content, err := deps.GetContent(args.Src)
+		getContent := deps.GetContent
+		if !args.Legacy && deps.GetLosslessContent != nil {
+			getContent = deps.GetLosslessContent
+		}
+		content, err := getContent(args.Src)
 		if err != nil {
 			deps.errorln("Error reading file:", err)
 			return err
@@ -170,6 +175,7 @@ func MainWithDependencies(exit func(int), userHomeDir func() (string, error)) {
 			return fmt.Fprintln(os.Stderr, values...)
 		},
 		GetContent:            Fn.GetPathContent,
+		GetLosslessContent:    Fn.ReadConfigFile,
 		SaveFile:              atomicSave,
 		SaveLossless:          atomicSave,
 		GetUserInputFromStdin: Fn.GetUserInputFromStdin,

--- a/main_test.go
+++ b/main_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	Cmd "github.com/soulteary/ssh-config/v3/cmd"
@@ -294,6 +295,40 @@ func TestRunExplicitSourceTakesPrecedenceOverStdin(t *testing.T) {
 	}
 	if string(output) != "Host source\n" {
 		t.Fatalf("output = %q", output)
+	}
+}
+
+func TestRunDefaultFileModeBypassesLegacyScanner(t *testing.T) {
+	t.Parallel()
+
+	source := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(source, []byte("Host source\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	want := []byte("Host source\n# " + strings.Repeat("x", 1024*1024+1) + "\n")
+	err := Run(Cmd.Args{ToSSH: true, Src: source}, Dependencies{
+		Println:       func(...interface{}) (int, error) { return 0, nil },
+		CheckUseStdin: func() bool { return false },
+		GetContent: func(string) ([]byte, error) {
+			t.Fatal("default mode called the legacy scanner")
+			return nil, nil
+		},
+		GetLosslessContent: func(path string) ([]byte, error) {
+			if path != source {
+				t.Fatalf("source path = %q, want %q", path, source)
+			}
+			return want, nil
+		},
+		Process: func(_ string, input string, _ Cmd.Args) ([]byte, error) {
+			if !bytes.Equal([]byte(input), want) {
+				t.Fatal("processor did not receive the lossless input")
+			}
+			return []byte(input), nil
+		},
+		WriteOutput: func([]byte) error { return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a single-file reader that validates the opened path and preserves every byte
- route the default lossless CLI path around the legacy directory scanner
- keep legacy directory discovery on the existing scanner
- cover lines larger than the legacy 1 MiB scanner limit and verify the default path selection

This removes the default mode's redundant scan/read cycle and prevents valid long lines from being rejected before the lossless parser sees them.

## Validation

- `go test ./...`
- `git diff --check`