### PR TITLE
fix: reject unsupported CLI positional arguments

### DIFF
--- a/cmd/argv.go
+++ b/cmd/argv.go
@@ -22,6 +22,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -45,6 +46,9 @@ type Args struct {
 	DocumentPath string
 	ShowHelp     bool
 	Version      bool
+	// Positionals contains arguments that were not parsed as flags. The CLI
+	// does not accept positional arguments, so callers must reject this list.
+	Positionals []string
 }
 
 const (
@@ -77,6 +81,9 @@ func ParseArgs() Args {
 	once.Do(func() {
 		initFlags()
 		flag.Parse()
+		if remaining := flag.Args(); len(remaining) > 0 {
+			args.Positionals = append([]string(nil), remaining...)
+		}
 	})
 	return args
 }
@@ -111,6 +118,10 @@ func CheckUseStdin(osStdinStat func() (fs.FileInfo, error)) bool {
 }
 
 func CheckConvertArgvValid(args Args) (result bool, desc string) {
+	if len(args.Positionals) > 0 {
+		return false, fmt.Sprintf("Unexpected positional arguments: %s", strings.Join(args.Positionals, " "))
+	}
+
 	trueCount := 0
 	if args.ToJSON {
 		trueCount++

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -92,6 +92,12 @@ func TestCheckConvertArgvValid(t *testing.T) {
 			wantResult: false,
 			wantDesc:   "Please specify either -to-yaml or -to-ssh or -to-json",
 		},
+		{
+			name:       "Positional arguments are rejected",
+			args:       Cmd.Args{ToYAML: true, Positionals: []string{"input.yaml", "-to-json"}},
+			wantResult: false,
+			wantDesc:   "Unexpected positional arguments: input.yaml -to-json",
+		},
 	}
 
 	for _, tt := range tests {
@@ -314,6 +320,13 @@ func TestParseArgs(t *testing.T) {
 				Src:      "input.yaml",
 				Dest:     "",
 				ShowHelp: false,
+			},
+		},
+		{
+			name: "Keep all arguments after the first positional",
+			args: []string{"input.yaml", "-to-json"},
+			expected: Cmd.Args{
+				Positionals: []string{"input.yaml", "-to-json"},
 			},
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	Cmd "github.com/soulteary/ssh-config/v3/cmd"
 	Fn "github.com/soulteary/ssh-config/v3/internal/fn"
@@ -183,6 +184,11 @@ func MainWithDependencies(exit func(int), userHomeDir func() (string, error)) {
 		UserHomeDir:   userHomeDir,
 	}
 	args := Cmd.ParseArgs()
+	if len(args.Positionals) > 0 {
+		fmt.Fprintf(os.Stderr, "Unexpected positional arguments: %s\n", strings.Join(args.Positionals, " "))
+		exit(2)
+		return
+	}
 	if args.ShowHelp {
 		fmt.Print(Cmd.Usage)
 		return

--- a/main_test.go
+++ b/main_test.go
@@ -441,6 +441,24 @@ func TestMainWithDependencies(t *testing.T) {
 				return "", errors.New("home must not be queried")
 			},
 		},
+		{
+			name:          "Positional argument stops later option parsing",
+			args:          []string{"cmd", "input.yaml", "-version"},
+			expectedError: "Unexpected positional arguments: input.yaml -version\n",
+			expectedExit:  2,
+			mockHomeDir: func() (string, error) {
+				return "", errors.New("home must not be queried")
+			},
+		},
+		{
+			name:          "Help does not hide a positional argument",
+			args:          []string{"cmd", "-help", "extra"},
+			expectedError: "Unexpected positional arguments: extra\n",
+			expectedExit:  2,
+			mockHomeDir: func() (string, error) {
+				return "", errors.New("home must not be queried")
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- retain every argument left after Go's flag parser encounters a positional token
- reject unsupported positionals before `-help` or `-version` can hide them
- return exit code 2 for this command-line usage error
- enforce the same invariant in `Run` for embedded callers

This prevents commands such as `ssh-config input -to-json` from silently defaulting to YAML while treating `-to-json` as an unparsed positional.

## Validation

- `go test ./...`
- `git diff --check`