### PR TITLE
feat: add resource limits for untrusted parser inputs

### DIFF
--- a/docs/lossless-schema-v3.md
+++ b/docs/lossless-schema-v3.md
@@ -117,6 +117,16 @@ if err != nil {
 encoded, err := sshconfig.MarshalSchemaYAML(sshconfig.NewSchema(schemaDoc))
 ```
 
+For untrusted streams, use `ParseReader` with a byte limit:
+
+```go
+doc, err := sshconfig.ParseReader(reader, sshconfig.ParseOptions{MaxBytes: 4 << 20})
+```
+
+`ResolveIncludes` also accepts `MaxFileBytes`, `MaxTotalBytes`, and `MaxFiles`
+in `ResolveOptions`. Set these limits when Include graphs are supplied by an
+untrusted caller; zero keeps the corresponding limit disabled.
+
 Use `UnmarshalSchemaYAML` or `UnmarshalSchemaJSON` for strict decoding, then
 call `Schema.Document(path)` and `Document.MarshalPreserve()` to reconstruct
 SSH source.

--- a/pkg/sshconfig/include.go
+++ b/pkg/sshconfig/include.go
@@ -2,7 +2,6 @@ package sshconfig
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -27,6 +26,15 @@ type ResolveOptions struct {
 	Tokens map[byte]string
 	// CheckPermissions rejects files writable by group or others.
 	CheckPermissions bool
+	// MaxFileBytes rejects any one entry or included file above this size.
+	// Zero means unlimited.
+	MaxFileBytes int64
+	// MaxTotalBytes limits bytes read across the traversal, including repeated
+	// Include matches. Zero means unlimited.
+	MaxTotalBytes int64
+	// MaxFiles limits file reads across the traversal, including repeated
+	// Include matches. Zero means unlimited.
+	MaxFiles int
 }
 
 // ResolvedFile is one parsed file in an Include graph.
@@ -49,7 +57,9 @@ type DocumentGraph struct {
 	Files map[string]*ResolvedFile
 	Edges []IncludeEdge
 	// Order records traversal order, including repeated non-recursive includes.
-	Order []string
+	Order         []string
+	resolvedBytes int64
+	resolvedFiles int
 }
 
 // ResolveIncludes parses entry and recursively builds its Include graph.
@@ -57,6 +67,9 @@ type DocumentGraph struct {
 func ResolveIncludes(entry string, options ResolveOptions) (*DocumentGraph, error) {
 	if entry == "" {
 		return nil, fmt.Errorf("sshconfig: include entry path is empty")
+	}
+	if options.MaxFileBytes < 0 || options.MaxTotalBytes < 0 || options.MaxFiles < 0 {
+		return nil, fmt.Errorf("sshconfig: include resource limits must not be negative")
 	}
 	absolute, err := filepath.Abs(entry)
 	if err != nil {
@@ -91,6 +104,9 @@ func (g *DocumentGraph) resolveFile(path string, options ResolveOptions, depth i
 	if stack[path] {
 		return fmt.Errorf("sshconfig: recursive include cycle at %s", path)
 	}
+	if options.MaxFiles > 0 && g.resolvedFiles >= options.MaxFiles {
+		return fmt.Errorf("sshconfig: include file count exceeds %d at %s", options.MaxFiles, path)
+	}
 	file, err := openIncludeFile(path)
 	if err != nil {
 		return fmt.Errorf("sshconfig: read included file %s: %w", path, err)
@@ -101,10 +117,16 @@ func (g *DocumentGraph) resolveFile(path string, options ResolveOptions, depth i
 			return err
 		}
 	}
-	data, err := io.ReadAll(file)
+	data, err := readAllLimited(file, options.MaxFileBytes, fmt.Sprintf("included file %s", path))
 	if err != nil {
 		return fmt.Errorf("sshconfig: read included file %s: %w", path, err)
 	}
+	dataBytes := int64(len(data))
+	if options.MaxTotalBytes > 0 && (dataBytes > options.MaxTotalBytes || g.resolvedBytes > options.MaxTotalBytes-dataBytes) {
+		return fmt.Errorf("sshconfig: include bytes exceed total limit of %d at %s", options.MaxTotalBytes, path)
+	}
+	g.resolvedBytes += dataBytes
+	g.resolvedFiles++
 	doc, err := Parse(data)
 	if err != nil {
 		return fmt.Errorf("sshconfig: parse included file %s: %w", path, err)

--- a/pkg/sshconfig/include_test.go
+++ b/pkg/sshconfig/include_test.go
@@ -152,6 +152,49 @@ func TestResolveIncludesExpansionErrors(t *testing.T) {
 	}
 }
 
+func TestResolveIncludesResourceLimits(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	entry := filepath.Join(directory, "config")
+	target := filepath.Join(directory, "included")
+	entryContent := "Include included\n"
+	targetContent := "Host included\n"
+	writeTestConfig(t, entry, entryContent)
+	writeTestConfig(t, target, targetContent)
+
+	tests := []struct {
+		name    string
+		options ResolveOptions
+		wantErr string
+	}{
+		{name: "file count", options: ResolveOptions{RelativeBase: directory, MaxFiles: 1}, wantErr: "file count exceeds"},
+		{name: "single file bytes", options: ResolveOptions{RelativeBase: directory, MaxFileBytes: int64(len(entryContent) - 1)}, wantErr: "exceeds maximum size"},
+		{name: "total bytes", options: ResolveOptions{RelativeBase: directory, MaxTotalBytes: int64(len(entryContent) + len(targetContent) - 1)}, wantErr: "total limit"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ResolveIncludes(entry, test.options)
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("ResolveIncludes() error = %v, want %q", err, test.wantErr)
+			}
+		})
+	}
+
+	graph, err := ResolveIncludes(entry, ResolveOptions{
+		RelativeBase:  directory,
+		MaxFiles:      2,
+		MaxFileBytes:  int64(len(entryContent)),
+		MaxTotalBytes: int64(len(entryContent) + len(targetContent)),
+	})
+	if err != nil {
+		t.Fatalf("exact resource limits: %v", err)
+	}
+	if len(graph.Order) != 2 {
+		t.Fatalf("order = %v", graph.Order)
+	}
+}
+
 func writeTestConfig(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {

--- a/pkg/sshconfig/reader.go
+++ b/pkg/sshconfig/reader.go
@@ -1,0 +1,53 @@
+package sshconfig
+
+import (
+	"fmt"
+	"io"
+)
+
+// ParseOptions controls resource use while reading a lossless document.
+type ParseOptions struct {
+	// MaxBytes rejects larger inputs. Zero means unlimited.
+	MaxBytes int64
+}
+
+// ParseReader reads and parses a lossless document. Use MaxBytes when the
+// source is not trusted by the application.
+func ParseReader(reader io.Reader, options ParseOptions) (*Document, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("sshconfig: input reader is nil")
+	}
+	if options.MaxBytes < 0 {
+		return nil, fmt.Errorf("sshconfig: MaxBytes must not be negative")
+	}
+	input, err := readAllLimited(reader, options.MaxBytes, "input")
+	if err != nil {
+		return nil, err
+	}
+	return Parse(input)
+}
+
+func readAllLimited(reader io.Reader, maxBytes int64, subject string) ([]byte, error) {
+	if maxBytes <= 0 {
+		return io.ReadAll(reader)
+	}
+
+	limited := &io.LimitedReader{R: reader, N: maxBytes}
+	input, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(input)) < maxBytes {
+		return input, nil
+	}
+
+	var probe [1]byte
+	n, probeErr := io.ReadFull(reader, probe[:])
+	if n > 0 {
+		return nil, fmt.Errorf("sshconfig: %s exceeds maximum size of %d bytes", subject, maxBytes)
+	}
+	if probeErr != nil && probeErr != io.EOF {
+		return nil, probeErr
+	}
+	return input, nil
+}

--- a/pkg/sshconfig/reader_test.go
+++ b/pkg/sshconfig/reader_test.go
@@ -1,0 +1,27 @@
+package sshconfig
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseReaderLimitsInput(t *testing.T) {
+	t.Parallel()
+	input := "Host example\n"
+
+	if _, err := ParseReader(strings.NewReader(input), ParseOptions{MaxBytes: int64(len(input))}); err != nil {
+		t.Fatalf("exact limit: %v", err)
+	}
+	if _, err := ParseReader(strings.NewReader(input), ParseOptions{MaxBytes: int64(len(input) - 1)}); err == nil || !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Fatalf("over limit error = %v", err)
+	}
+	if _, err := ParseReader(strings.NewReader(input), ParseOptions{}); err != nil {
+		t.Fatalf("unlimited input: %v", err)
+	}
+	if _, err := ParseReader(nil, ParseOptions{}); err == nil || !strings.Contains(err.Error(), "nil") {
+		t.Fatalf("nil reader error = %v", err)
+	}
+	if _, err := ParseReader(strings.NewReader(input), ParseOptions{MaxBytes: -1}); err == nil || !strings.Contains(err.Error(), "negative") {
+		t.Fatalf("negative limit error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add `ParseReader` with an opt-in `MaxBytes` limit
- add per-file, total-byte, and file-count limits to `ResolveOptions`
- count repeated Include traversal reads against the configured budgets
- preserve zero-value compatibility as unlimited
- document the limits and cover exact-boundary, over-limit, nil-reader, and Include graph cases

These opt-in budgets let library consumers safely process untrusted streams and Include graphs without changing existing callers.

## Validation

- `go test ./...`
- `git diff --check`