### PR TITLE
docs: validate local links and identify the legacy guide

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Documentation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - "integration/docs_test.go"
+      - ".github/workflows/docs.yml"
+  push:
+    branches: [main]
+    paths:
+      - "**/*.md"
+      - "integration/docs_test.go"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  links:
+    name: Validate local documentation links
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Validate links
+        run: go test ./integration -run '^TestDocumentationLinks$'

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ This project is licensed under the Apache License. See the [LICENSE](./LICENSE) 
 
 # Guide
 
-- [SSH Config Tool: Use structured data to manage SSH configuration](https://soulteary.com/2024/10/15/manage-ssh-configuration-using-structure-data-ssh-config-tool.html)
+- [Legacy v1/v2 guide: SSH Config Tool](https://soulteary.com/2024/10/15/manage-ssh-configuration-using-structure-data-ssh-config-tool.html) — v3 users must add `-legacy` for the directory-scan and legacy schema commands shown there; see the [migration guide](./docs/migration-v3.md).
 
 # Credits
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -166,7 +166,7 @@ go test -v ./... -covermode=atomic -coverprofile=coverage.out && go tool cover -
 
 # 使用教程
 
-- [使用结构化数据管理 SSH 配置：SSH Config Tool](https://soulteary.com/2024/10/15/manage-ssh-configuration-using-structure-data-ssh-config-tool.html)
+- [v1/v2 旧版教程：使用结构化数据管理 SSH 配置](https://soulteary.com/2024/10/15/manage-ssh-configuration-using-structure-data-ssh-config-tool.html) — v3 用户执行其中的目录扫描和旧版数据格式命令时必须添加 `-legacy`；另请阅读 [v3 迁移指南](./docs/migration-v3.md)。
 
 # 感谢
 

--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -30,6 +30,11 @@ v3 and can be removed after every installation has upgraded. Legacy YAML and
 JSON remain valid inputs in the default mode and are migrated to v3; `-legacy`
 controls the output pipeline, not input compatibility.
 
+The linked October 2024 project guide predates v3. Its directory-scan and
+map-based YAML/JSON examples describe the legacy pipeline; add `-legacy` when
+following those examples with a v3 binary. Prefer the commands above for new
+automation.
+
 ## Go module path
 
 The public module path changes with the application major version:

--- a/integration/docs_test.go
+++ b/integration/docs_test.go
@@ -1,0 +1,85 @@
+package integration_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+var (
+	inlineMarkdownLink = regexp.MustCompile(`!?\[[^\]]*\]\(([^)]+)\)`)
+	referenceLink      = regexp.MustCompile(`(?m)^\s*\[[^\]]+\]:\s*(\S+)`)
+)
+
+func TestDocumentationLinks(t *testing.T) {
+	t.Parallel()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate documentation test")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(filename), ".."))
+	paths := []string{
+		filepath.Join(root, "README.md"),
+		filepath.Join(root, "README_CN.md"),
+		filepath.Join(root, "SECURITY.md"),
+		filepath.Join(root, "CONTRIBUTING.md"),
+	}
+	if err := filepath.WalkDir(filepath.Join(root, "docs"), func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() && strings.EqualFold(filepath.Ext(path), ".md") {
+			paths = append(paths, path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range paths {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %s: %v", filepath.ToSlash(path), err)
+			continue
+		}
+		matches := inlineMarkdownLink.FindAllSubmatch(content, -1)
+		matches = append(matches, referenceLink.FindAllSubmatch(content, -1)...)
+		for _, match := range matches {
+			checkDocumentationLink(t, root, path, string(match[1]))
+		}
+	}
+}
+
+func checkDocumentationLink(t *testing.T, root, source, destination string) {
+	t.Helper()
+	destination = strings.TrimSpace(destination)
+	if strings.HasPrefix(destination, "<") {
+		if end := strings.IndexByte(destination, '>'); end >= 0 {
+			destination = destination[1:end]
+		}
+	} else if separator := strings.IndexAny(destination, " \t"); separator >= 0 {
+		destination = destination[:separator]
+	}
+	if anchor := strings.IndexByte(destination, '#'); anchor >= 0 {
+		destination = destination[:anchor]
+	}
+	lower := strings.ToLower(destination)
+	if destination == "" || strings.HasPrefix(lower, "http://") ||
+		strings.HasPrefix(lower, "https://") || strings.HasPrefix(lower, "mailto:") {
+		return
+	}
+
+	var target string
+	if strings.HasPrefix(destination, "/") {
+		target = filepath.Join(root, filepath.FromSlash(strings.TrimPrefix(destination, "/")))
+	} else {
+		target = filepath.Join(filepath.Dir(source), filepath.FromSlash(destination))
+	}
+	if _, err := os.Stat(filepath.Clean(target)); err != nil {
+		relativeSource, _ := filepath.Rel(root, source)
+		t.Errorf("%s links to missing local path %q", filepath.ToSlash(relativeSource), destination)
+	}
+}


### PR DESCRIPTION
## Summary

- label the linked 2024 tutorial as a v1/v2 guide in both READMEs
- point v3 users to `-legacy` and the current migration guide
- add a focused documentation workflow for Markdown-only changes
- validate local inline and reference-style links across root documentation and `docs/`

This closes the gap where docs-only pull requests skip the main quality workflow and prevents the old tutorial from being mistaken for current v3 CLI behavior.

## Validation

- `go test ./...`
- `go test ./integration -run '^TestDocumentationLinks$'`
- `git diff --check`