### PR TITLE
build: harden the runtime container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,57 @@
+name: Container
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - ".github/workflows/container.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - ".github/workflows/container.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Build and smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build binary
+        shell: bash
+        run: |
+          mkdir -p linux/amd64
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o linux/amd64/ssh-config .
+
+      - name: Build image
+        shell: bash
+        run: docker build --build-arg TARGETPLATFORM=linux/amd64 --tag ssh-config:pr .
+
+      - name: Verify runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(docker image inspect --format '{{.Config.User}}' ssh-config:pr)" = "65532:65532"
+          docker run --rm ssh-config:pr -version
+          if docker run --rm --entrypoint /bin/bash ssh-config:pr -c true; then
+            echo "::error::runtime image unexpectedly contains Bash"
+            exit 1
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM alpine:3.24.1 AS builder
+ARG ALPINE_VERSION=3.24.1
+ARG ALPINE_DIGEST=sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+
+FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST} AS certificates
 RUN apk add --no-cache ca-certificates
 
-FROM alpine:3.24.1
-RUN apk add --no-cache bash
+FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST}
 LABEL maintainer "soulteary <soulteary@gmail.com>"
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/ssh-config /usr/bin/ssh-config
-SHELL ["/bin/bash", "-c"]
+USER 65532:65532
 ENTRYPOINT ["/usr/bin/ssh-config"]

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Convert file (test.yaml) in the current directory to YAML (abc.yaml):
 docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd):/ssh" soulteary/ssh-config:latest -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
 ```
 
+The image runs as the unprivileged numeric user `65532:65532` by default.
 Passing the host UID and GID keeps files written to the bind mount owned by
 the current user. It is not required when the result is written only to
 standard output.
@@ -81,11 +82,10 @@ Just want to see the conversion results:
 docker run --rm -it -v "$(pwd):/ssh" soulteary/ssh-config:latest -to-yaml -src /ssh/test.yaml
 ```
 
-If you want to use Linux pipelines, you can first enter the Docker interactive command line:
+Use `-i` to send a Linux pipeline directly to the container:
 
 ```bash
-docker run --rm -it --entrypoint bash -v "$(pwd):/ssh" soulteary/ssh-config:latest
-cat /ssh/test.yaml | ssh-config -to-yaml
+cat test.yaml | docker run --rm -i soulteary/ssh-config:latest -to-yaml
 ```
 
 ### Options

--- a/README_CN.md
+++ b/README_CN.md
@@ -76,8 +76,9 @@ docker pull ghcr.io/soulteary/ssh-config:latest
 docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd):/ssh" soulteary/ssh-config:latest -to-yaml -src /ssh/test.yaml -dest /ssh/abc.yaml
 ```
 
-写入挂载目录时传入宿主机当前用户的 UID 和 GID，可以避免生成
-`root:root` 且仅 root 可读的文件。只向标准输出打印结果时无需设置。
+镜像默认以无特权数字用户 `65532:65532` 运行。写入挂载目录时传入
+宿主机当前用户的 UID 和 GID，可以让生成文件直接归属当前用户。
+只向标准输出打印结果时无需设置。
 
 如果你只想看看转换结果：
 
@@ -85,11 +86,10 @@ docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd):/ssh" soulteary/ssh-co
 docker run --rm -it -v "$(pwd):/ssh" soulteary/ssh-config:latest -to-yaml -src /ssh/test.yaml
 ```
 
-如果你想使用 Linux 管道来操作文件，可以先进入 Docker 交互式命令行：
+使用 `-i` 可将 Linux 管道直接传入容器：
 
 ```bash
-docker run --rm -it --entrypoint bash -v "$(pwd):/ssh" soulteary/ssh-config:latest
-cat /ssh/test.yaml | ssh-config -to-yaml
+cat test.yaml | docker run --rm -i soulteary/ssh-config:latest -to-yaml
 ```
 
 ### 选项

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -17,3 +17,8 @@ additional `.sbom.json` suffix. Container-native Buildx attestations are not
 currently emitted because the release publishes the same multi-platform image
 to registries with different attestation support. Archive provenance remains
 independently verifiable through GitHub's Sigstore-backed attestation service.
+
+The runtime image pins its Alpine base by both version and digest, contains no
+interactive shell, and starts the converter as the unprivileged numeric user
+`65532:65532`. Supply a host UID/GID explicitly only when bind-mounted output
+must be owned by that host user.


### PR DESCRIPTION
## Summary

- pin Alpine 3.24.1 by immutable multi-platform digest
- remove Bash from the runtime image
- run the converter as numeric user `65532:65532` by default
- replace the interactive-shell pipeline instructions with direct stdin usage
- add a path-scoped container workflow that builds and smoke-tests Dockerfile changes
- document the runtime hardening choices

## Validation

- `git diff --check`
- PR workflow builds the Linux binary and image
- PR workflow verifies `65532:65532`, runs `-version`, and asserts `/bin/bash` is absent