### PR TITLE
fix: preserve effective legacy host identities

### DIFF
--- a/internal/fn/config.go
+++ b/internal/fn/config.go
@@ -22,7 +22,7 @@ import (
 
 func FindGlobalConfig(configs []Define.HostConfig) (result []Define.HostConfig) {
 	for _, config := range configs {
-		if config.Name == "*" {
+		if config.Extra.Prefix+config.Name == "*" {
 			result = append(result, config)
 		}
 	}
@@ -31,7 +31,7 @@ func FindGlobalConfig(configs []Define.HostConfig) (result []Define.HostConfig) 
 
 func FindNormalConfig(configs []Define.HostConfig) (result []Define.HostConfig) {
 	for _, config := range configs {
-		if config.Name != "*" {
+		if config.Extra.Prefix+config.Name != "*" {
 			result = append(result, config)
 		}
 	}

--- a/internal/fn/config_test.go
+++ b/internal/fn/config_test.go
@@ -79,6 +79,21 @@ func TestFindGlobalConfigNoGlobal(t *testing.T) {
 	}
 }
 
+func TestFindGlobalConfigUsesEffectiveHostName(t *testing.T) {
+	configs := []Define.HostConfig{
+		{Name: "*", Extra: Define.HostExtraConfig{Prefix: "work-"}},
+		{Name: "*"},
+	}
+	global := Fn.FindGlobalConfig(configs)
+	if len(global) != 1 || global[0].Extra.Prefix != "" {
+		t.Fatalf("FindGlobalConfig() = %#v, want only the unprefixed wildcard", global)
+	}
+	normal := Fn.FindNormalConfig(configs)
+	if len(normal) != 1 || normal[0].Extra.Prefix != "work-" {
+		t.Fatalf("FindNormalConfig() = %#v, want the prefixed wildcard", normal)
+	}
+}
+
 func TestFindNormalConfig(t *testing.T) {
 	configs := []Define.HostConfig{
 		{Name: "host1", Notes: "Test host 1", Config: map[string]string{"key1": "value1"}},

--- a/internal/parser/legacy_safety_test.go
+++ b/internal/parser/legacy_safety_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	Define "github.com/soulteary/ssh-config/v3/internal/define"
 	Parser "github.com/soulteary/ssh-config/v3/internal/parser"
 )
 
@@ -71,6 +72,47 @@ func TestGroupYAMLConfigPreservesHostWithoutConfig(t *testing.T) {
 	output := string(Parser.ConvertToSSH(configs))
 	if !strings.Contains(output, "Host example\n") {
 		t.Fatalf("ConvertToSSH() dropped empty host:\n%s", output)
+	}
+}
+
+func TestGroupYAMLConfigPreservesPrefixedWildcardHost(t *testing.T) {
+	t.Parallel()
+
+	configs, err := Parser.GroupYAMLConfigStrict(`Group work:
+  Prefix: work-
+  Hosts:
+    "*": {}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := string(Parser.ConvertToSSH(configs))
+	if !strings.Contains(output, "Host work-*\n") {
+		t.Fatalf("ConvertToSSH() changed the prefixed wildcard host:\n%s", output)
+	}
+}
+
+func TestConvertToYAMLPreservesRepeatedRawNamesAcrossPrefixes(t *testing.T) {
+	t.Parallel()
+
+	input := []Define.HostConfig{
+		{Name: "x", Extra: Define.HostExtraConfig{Prefix: "a-"}},
+		{Name: "x", Extra: Define.HostExtraConfig{Prefix: "b-"}},
+	}
+	encoded := Parser.ConvertToYAML(input)
+	configs, err := Parser.GroupYAMLConfigStrict(string(encoded))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(configs) != 2 {
+		t.Fatalf("round trip retained %d hosts, want 2:\n%s", len(configs), encoded)
+	}
+	effective := map[string]bool{}
+	for _, config := range configs {
+		effective[config.Extra.Prefix+config.Name] = true
+	}
+	if !effective["a-x"] || !effective["b-x"] {
+		t.Fatalf("round-trip hosts = %#v, want a-x and b-x", configs)
 	}
 }
 

--- a/internal/parser/yaml.go
+++ b/internal/parser/yaml.go
@@ -81,11 +81,9 @@ func ConvertToYAML(hostConfigs []Define.HostConfig) []byte {
 
 	normalConfigs := Fn.FindNormalConfig(hostConfigs)
 	if len(normalConfigs) > 0 {
-		groupNames := make([]string, 0, len(normalConfigs))
-		groupsData := make(map[string]yaml.MapSlice)
+		usedGroupNames := make(map[string]bool)
 		for _, config := range normalConfigs {
-			groupName := fmt.Sprintf("Group %s", config.Name)
-			groupNames = append(groupNames, groupName)
+			groupName := uniqueLegacyGroupName(config, usedGroupNames)
 			groupHostConfig := Define.HostConfig{}
 			if config.Notes != "" {
 				groupHostConfig.Notes = config.Notes
@@ -100,10 +98,7 @@ func ConvertToYAML(hostConfigs []Define.HostConfig) []byte {
 			if config.Extra.Prefix != "" {
 				groupItems = append(yaml.MapSlice{{Key: "Prefix", Value: config.Extra.Prefix}}, groupItems...)
 			}
-			groupsData[groupName] = groupItems
-		}
-		for _, groupName := range groupNames {
-			root = append(root, yaml.MapItem{Key: groupName, Value: groupsData[groupName]})
+			root = append(root, yaml.MapItem{Key: groupName, Value: groupItems})
 		}
 	}
 
@@ -113,6 +108,27 @@ func ConvertToYAML(hostConfigs []Define.HostConfig) []byte {
 		return nil
 	}
 	return yamlData
+}
+
+func uniqueLegacyGroupName(config Define.HostConfig, used map[string]bool) string {
+	base := fmt.Sprintf("Group %s", config.Name)
+	if !used[base] {
+		used[base] = true
+		return base
+	}
+
+	effective := fmt.Sprintf("Group %s%s", config.Extra.Prefix, config.Name)
+	if !used[effective] {
+		used[effective] = true
+		return effective
+	}
+	for suffix := 2; ; suffix++ {
+		candidate := fmt.Sprintf("%s (%d)", effective, suffix)
+		if !used[candidate] {
+			used[candidate] = true
+			return candidate
+		}
+	}
 }
 
 type YAMLHostConfigGroup struct {


### PR DESCRIPTION
## Summary

- classify legacy global hosts using `Prefix + Name` instead of the raw name
- preserve prefixed wildcard hosts such as `work-*` during `-to-ssh`
- generate deterministic unique YAML group keys when different prefixes share a raw host name
- add round-trip regression coverage for both review cases

Follow-up to #105 and its two automated review findings.

## Validation

- `git diff --check`
- full Go test suite runs in the PR Quality workflow