### PR TITLE
fix: enforce Include total-byte limits during reads

### DIFF
--- a/pkg/sshconfig/include.go
+++ b/pkg/sshconfig/include.go
@@ -117,7 +117,28 @@ func (g *DocumentGraph) resolveFile(path string, options ResolveOptions, depth i
 			return err
 		}
 	}
-	data, err := readAllLimited(file, options.MaxFileBytes, fmt.Sprintf("included file %s", path))
+	readLimit := options.MaxFileBytes
+	totalLimitApplied := false
+	if options.MaxTotalBytes > 0 {
+		remaining := options.MaxTotalBytes - g.resolvedBytes
+		if readLimit <= 0 || remaining <= readLimit {
+			readLimit = remaining
+			totalLimitApplied = true
+		}
+	}
+	var data []byte
+	if readLimit > 0 || options.MaxTotalBytes > 0 {
+		var exceeded bool
+		data, exceeded, err = readAllAtMost(file, readLimit)
+		if exceeded {
+			if totalLimitApplied {
+				return fmt.Errorf("sshconfig: include bytes exceed total limit of %d at %s", options.MaxTotalBytes, path)
+			}
+			return fmt.Errorf("sshconfig: included file %s exceeds maximum size of %d bytes", path, options.MaxFileBytes)
+		}
+	} else {
+		data, err = readAllLimited(file, 0, "")
+	}
 	if err != nil {
 		return fmt.Errorf("sshconfig: read included file %s: %w", path, err)
 	}

--- a/pkg/sshconfig/reader.go
+++ b/pkg/sshconfig/reader.go
@@ -31,23 +31,33 @@ func readAllLimited(reader io.Reader, maxBytes int64, subject string) ([]byte, e
 	if maxBytes <= 0 {
 		return io.ReadAll(reader)
 	}
-
-	limited := &io.LimitedReader{R: reader, N: maxBytes}
-	input, err := io.ReadAll(limited)
+	input, exceeded, err := readAllAtMost(reader, maxBytes)
 	if err != nil {
 		return nil, err
 	}
+	if exceeded {
+		return nil, fmt.Errorf("sshconfig: %s exceeds maximum size of %d bytes", subject, maxBytes)
+	}
+	return input, nil
+}
+
+func readAllAtMost(reader io.Reader, maxBytes int64) ([]byte, bool, error) {
+	limited := &io.LimitedReader{R: reader, N: maxBytes}
+	input, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, false, err
+	}
 	if int64(len(input)) < maxBytes {
-		return input, nil
+		return input, false, nil
 	}
 
 	var probe [1]byte
 	n, probeErr := io.ReadFull(reader, probe[:])
 	if n > 0 {
-		return nil, fmt.Errorf("sshconfig: %s exceeds maximum size of %d bytes", subject, maxBytes)
+		return nil, true, nil
 	}
 	if probeErr != nil && probeErr != io.EOF {
-		return nil, probeErr
+		return nil, false, probeErr
 	}
-	return input, nil
+	return input, false, nil
 }

--- a/pkg/sshconfig/reader_test.go
+++ b/pkg/sshconfig/reader_test.go
@@ -1,6 +1,7 @@
 package sshconfig
 
 import (
+	"io"
 	"strings"
 	"testing"
 )
@@ -23,5 +24,31 @@ func TestParseReaderLimitsInput(t *testing.T) {
 	}
 	if _, err := ParseReader(strings.NewReader(input), ParseOptions{MaxBytes: -1}); err == nil || !strings.Contains(err.Error(), "negative") {
 		t.Fatalf("negative limit error = %v", err)
+	}
+}
+
+type countingReader struct {
+	reader io.Reader
+	read   int
+}
+
+func (reader *countingReader) Read(buffer []byte) (int, error) {
+	count, err := reader.reader.Read(buffer)
+	reader.read += count
+	return count, err
+}
+
+func TestReadAllAtMostStopsAfterTheBudget(t *testing.T) {
+	t.Parallel()
+	reader := &countingReader{reader: strings.NewReader(strings.Repeat("x", 1024*1024))}
+	_, exceeded, err := readAllAtMost(reader, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exceeded {
+		t.Fatal("readAllAtMost() accepted an oversized stream")
+	}
+	if reader.read != 9 {
+		t.Fatalf("readAllAtMost() consumed %d bytes, want the 8-byte budget plus one probe", reader.read)
 	}
 }


### PR DESCRIPTION
## Summary

- calculate the remaining traversal budget before reading each Include target
- apply the smaller of the per-file and remaining-total limits to the reader
- support an exact zero-byte remaining budget without treating it as unlimited
- verify oversized readers consume only the configured budget plus one probe byte

This closes the allocation bypass identified after #109: a small `MaxTotalBytes` value can no longer allow an arbitrarily large file to be read into memory before rejection.

## Validation

- `git diff --check`
- full Go test suite runs in the PR Quality workflow