### PR TITLE
fix: provide a stable home for the container user

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -50,7 +50,12 @@ jobs:
         run: |
           set -euo pipefail
           test "$(docker image inspect --format '{{.Config.User}}' ssh-config:pr)" = "65532:65532"
+          docker image inspect --format '{{range .Config.Env}}{{println .}}{{end}}' ssh-config:pr | grep -qx 'HOME=/home/ssh-config'
           docker run --rm ssh-config:pr -version
+          runtime_home="$(mktemp -d)"
+          printf 'Host default\n' > "${runtime_home}/config"
+          chmod 0755 "${runtime_home}"
+          docker run --rm -v "${runtime_home}:/home/ssh-config/.ssh:ro" ssh-config:pr -to-yaml | grep -q 'schemaVersion: 3'
           if docker run --rm --entrypoint /bin/bash ssh-config:pr -c true; then
             echo "::error::runtime image unexpectedly contains Bash"
             exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ RUN apk add --no-cache ca-certificates
 FROM alpine:${ALPINE_VERSION}@${ALPINE_DIGEST}
 LABEL maintainer "soulteary <soulteary@gmail.com>"
 COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+RUN addgroup -S -g 65532 ssh-config \
+    && adduser -S -D -u 65532 -G ssh-config -h /home/ssh-config ssh-config \
+    && mkdir -p /home/ssh-config/.ssh \
+    && chown -R 65532:65532 /home/ssh-config
+ENV HOME=/home/ssh-config
 ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/ssh-config /usr/bin/ssh-config
 USER 65532:65532

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ Passing the host UID and GID keeps files written to the bind mount owned by
 the current user. It is not required when the result is written only to
 standard output.
 
+The default home is `/home/ssh-config`. To use the default source path without
+passing `-src`, mount an SSH directory there as read-only:
+
+```bash
+docker run --rm -v "$HOME/.ssh:/home/ssh-config/.ssh:ro" soulteary/ssh-config:latest -to-yaml
+```
+
 Just want to see the conversion results:
 
 ```bash

--- a/README_CN.md
+++ b/README_CN.md
@@ -80,6 +80,13 @@ docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd):/ssh" soulteary/ssh-co
 宿主机当前用户的 UID 和 GID，可以让生成文件直接归属当前用户。
 只向标准输出打印结果时无需设置。
 
+容器内的默认主目录为 `/home/ssh-config`。如需省略 `-src` 并读取默认
+配置路径，请将 SSH 目录以只读方式挂载到该目录：
+
+```bash
+docker run --rm -v "$HOME/.ssh:/home/ssh-config/.ssh:ro" soulteary/ssh-config:latest -to-yaml
+```
+
 如果你只想看看转换结果：
 
 ```bash

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -18,7 +18,8 @@ currently emitted because the release publishes the same multi-platform image
 to registries with different attestation support. Archive provenance remains
 independently verifiable through GitHub's Sigstore-backed attestation service.
 
-The runtime image pins its Alpine base by both version and digest, contains no
-interactive shell, and starts the converter as the unprivileged numeric user
-`65532:65532`. Supply a host UID/GID explicitly only when bind-mounted output
-must be owned by that host user.
+The runtime image pins its Alpine base by both version and digest, does not
+install Bash, and starts the converter as the passwd-backed, unprivileged
+numeric user `65532:65532` with `/home/ssh-config` as its home. Alpine's BusyBox
+`/bin/sh` remains available. Supply a host UID/GID explicitly only when
+bind-mounted output must be owned by that host user.


### PR DESCRIPTION
## Summary

- create a passwd-backed `ssh-config` user for numeric UID/GID 65532
- set a stable writable `HOME=/home/ssh-config`
- document the default read-only SSH directory mount in English and Chinese
- smoke-test no-`-src` default-path conversion
- accurately document that Bash is absent while Alpine BusyBox `/bin/sh` remains

Follow-up to #111 and its two automated review findings.

## Validation

- `git diff --check`
- the Container workflow builds the image and verifies its user, HOME, default path, version command, and Bash absence