### PR TITLE
docs: make private SSH directory mounts readable

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -54,8 +54,8 @@ jobs:
           docker run --rm ssh-config:pr -version
           runtime_home="$(mktemp -d)"
           printf 'Host default\n' > "${runtime_home}/config"
-          chmod 0755 "${runtime_home}"
-          docker run --rm -v "${runtime_home}:/home/ssh-config/.ssh:ro" ssh-config:pr -to-yaml | grep -q 'schemaVersion: 3'
+          chmod 0600 "${runtime_home}/config"
+          docker run --rm --user "$(id -u):$(id -g)" -v "${runtime_home}:/home/ssh-config/.ssh:ro" ssh-config:pr -to-yaml | grep -q 'schemaVersion: 3'
           if docker run --rm --entrypoint /bin/bash ssh-config:pr -c true; then
             echo "::error::runtime image unexpectedly contains Bash"
             exit 1

--- a/README.md
+++ b/README.md
@@ -80,8 +80,11 @@ The default home is `/home/ssh-config`. To use the default source path without
 passing `-src`, mount an SSH directory there as read-only:
 
 ```bash
-docker run --rm -v "$HOME/.ssh:/home/ssh-config/.ssh:ro" soulteary/ssh-config:latest -to-yaml
+docker run --rm --user "$(id -u):$(id -g)" -v "$HOME/.ssh:/home/ssh-config/.ssh:ro" soulteary/ssh-config:latest -to-yaml
 ```
+
+The host UID/GID is required for the usual private `~/.ssh` permissions
+(`0700` directory and `0600` config).
 
 Just want to see the conversion results:
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -84,8 +84,11 @@ docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd):/ssh" soulteary/ssh-co
 配置路径，请将 SSH 目录以只读方式挂载到该目录：
 
 ```bash
-docker run --rm -v "$HOME/.ssh:/home/ssh-config/.ssh:ro" soulteary/ssh-config:latest -to-yaml
+docker run --rm --user "$(id -u):$(id -g)" -v "$HOME/.ssh:/home/ssh-config/.ssh:ro" soulteary/ssh-config:latest -to-yaml
 ```
+
+宿主 UID/GID 用于读取常见的私有 SSH 权限（目录 `0700`、配置文件
+`0600`）。
 
 如果你只想看看转换结果：
 


### PR DESCRIPTION
## Summary

- run the documented default-path mount with the host UID/GID
- preserve realistic private SSH permissions instead of loosening the directory to `0755`
- set the smoke-test config to `0600` and verify conversion under the host identity
- update both English and Chinese instructions

Follow-up to #115 and its post-merge review finding.

## Validation

- `git diff --check`
- the Container workflow exercises a `0700` directory with a `0600` config file