### PR TITLE
fix: render prefix-only global hosts correctly

### DIFF
--- a/internal/parser/legacy_safety_test.go
+++ b/internal/parser/legacy_safety_test.go
@@ -92,6 +92,23 @@ func TestGroupYAMLConfigPreservesPrefixedWildcardHost(t *testing.T) {
 	}
 }
 
+func TestGroupYAMLConfigRendersPrefixOnlyGlobalHost(t *testing.T) {
+	t.Parallel()
+
+	configs, err := Parser.GroupYAMLConfigStrict(`Group wildcard:
+  Prefix: "*"
+  Hosts:
+    "": {}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	output := string(Parser.ConvertToSSH(configs))
+	if !strings.Contains(output, "Host *\n") {
+		t.Fatalf("ConvertToSSH() lost the prefix-only global host:\n%s", output)
+	}
+}
+
 func TestConvertToYAMLPreservesRepeatedRawNamesAcrossPrefixes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/parser/ssh.go
+++ b/internal/parser/ssh.go
@@ -379,7 +379,8 @@ func ConvertToSSH(hostConfigs []Define.HostConfig) []byte {
 					lines = append(lines, fmt.Sprintf("# %s", note))
 				}
 			}
-			lines = append(lines, fmt.Sprintf("Host %s", renderLegacyHostPatterns(config.Name)))
+			hostName := config.Extra.Prefix + config.Name
+			lines = append(lines, fmt.Sprintf("Host %s", renderLegacyHostPatterns(hostName)))
 
 			orderMaps := Fn.GetOrderMaps(config.Config)
 			for _, field := range orderMaps.Keys {


### PR DESCRIPTION
## Summary

- render legacy global `Host` patterns from the effective `Prefix + Name`
- preserve the normal unprefixed `Host *` behavior
- cover the accepted `Prefix: "*"` plus empty host-key representation

Follow-up to #112 and its post-merge review finding.

## Validation

- `git diff --check`
- the Quality workflow runs the complete Go test suite